### PR TITLE
Expose banner at package level

### DIFF
--- a/ghast/__init__.py
+++ b/ghast/__init__.py
@@ -7,6 +7,7 @@ based on industry best practices.
 """
 
 from ghast.utils.version import __version__, get_version, get_version_info
+from .utils.banner import _BANNER
 
 from .core import (
     Finding,


### PR DESCRIPTION
## Summary
- import `_BANNER` from `utils.banner` so it can be accessed at the top level package

## Testing
- `pytest -q` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_683f4f2879b8832886a3956514e69e7b