### PR TITLE
Fix testpath warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ["ghast/tests"]
 python_files = "test_*.py"
 python_functions = "test_*"
 python_classes = "Test*"


### PR DESCRIPTION
## Summary
- set pytest `testpaths` to `ghast/tests`

## Testing
- `pytest -q` *(fails: assert errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840b1d459a48328b2af5cd0cb8150d5