### PR TITLE
Update report version handling

### DIFF
--- a/ghast/reports/json.py
+++ b/ghast/reports/json.py
@@ -9,6 +9,8 @@ import json
 from typing import List, Dict, Any, Optional
 from datetime import datetime
 
+from ..utils.version import __version__
+
 from ..core import Finding
 
 
@@ -60,7 +62,7 @@ def generate_json_report(
     findings_data = [finding_to_dict(finding) for finding in findings]
 
     report = {
-        "ghast_version": "0.2.0",  # This should be dynamically determined in a real implementation
+        "ghast_version": __version__,
         "generated_at": datetime.now().isoformat(),
         "findings": findings_data,
     }
@@ -89,7 +91,7 @@ def generate_json_summary(stats: Dict[str, Any]) -> str:
     """
 
     summary = {
-        "ghast_version": "0.2.0",  # This should be dynamically determined in a real implementation
+        "ghast_version": __version__,
         "generated_at": datetime.now().isoformat(),
         "summary": {
             "total_files": stats.get("total_files", 0),

--- a/ghast/reports/sarif.py
+++ b/ghast/reports/sarif.py
@@ -15,6 +15,8 @@ from typing import List, Dict, Any, Set
 from datetime import datetime
 import hashlib
 
+from ..utils.version import __version__
+
 from ..core import Finding, SEVERITY_LEVELS
 
 SARIF_VERSION = "2.1.0"
@@ -129,7 +131,7 @@ def generate_sarif_report(
     stats: Dict[str, Any],
     repo_root: str = None,
     tool_name: str = "ghast",
-    tool_version: str = "0.2.0",
+    tool_version: str = __version__,
 ) -> str:
     """
     Generate a SARIF report from findings
@@ -207,7 +209,7 @@ def save_sarif_report(
     output_path: str,
     repo_root: str = None,
     tool_name: str = "ghast",
-    tool_version: str = "0.2.0",
+    tool_version: str = __version__,
 ) -> None:
     """
     Generate a SARIF report and save it to a file
@@ -280,7 +282,7 @@ def generate_sarif_suppression_file(findings: List[Finding], output_path: str) -
         "version": SARIF_VERSION,
         "runs": [
             {
-                "tool": {"driver": {"name": "ghast", "version": "0.2.0"}},
+                "tool": {"driver": {"name": "ghast", "version": __version__}},
                 "suppressions": suppressions,
             }
         ],


### PR DESCRIPTION
## Summary
- import version helper in JSON/SARIF reporters
- use `__version__` constant instead of hard-coded strings

## Testing
- `PYTHONPATH=. pytest ghast/tests/reports/test_json.py::test_generate_json_report -q`
- `PYTHONPATH=. pytest ghast/tests/reports/test_sarif.py::test_generate_sarif_report -q`
- `PYTHONPATH=. pytest -q` *(fails: test suite reports multiple errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840b1d3c6148328951364b3a1eafa87