### PR TITLE
Update README installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,15 @@ Inspired by [this security guide](https://www.wiz.io/blog/github-actions-securit
 
 ## 📋 Installation
 
+Install the latest release from PyPI:
+
 ```bash
-# Install from source
+pip install ghast
+```
+
+To install from source:
+
+```bash
 git clone https://github.com/seanwevans/ghast.git
 cd ghast
 pip install -e .


### PR DESCRIPTION
## Summary
- clarify installation steps with a `pip install ghast` example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685969d912008328a5db0eccf97dedb5