### PR TITLE
Add code of conduct and mention in README

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone. We pledge to act and interact in ways that
+contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Taking responsibility and apologizing to those affected by our mistakes
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+Project maintainers are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in response to any
+behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+This Code of Conduct applies within all project spaces and also applies when an individual
+is officially representing the project in public spaces.
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the
+project maintainers at <sean.w.evans@gmail.com>. All complaints will be reviewed and
+investigated promptly and fairly.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1.

--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ ghast helps identify and remediate these risks before they can be exploited.
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
+Please note that this project adheres to a [Code of Conduct](CODE_OF_CONDUCT.md).
+By participating, you are expected to uphold this code.
+
 1. Fork the repository
 2. Create your feature branch (`git checkout -b feature/amazing-feature`)
 3. Commit your changes (`git commit -m 'Add some amazing feature'`)


### PR DESCRIPTION
## Summary
- document community guidelines with a code of conduct
- link the code of conduct from the Contributing section of the README

## Testing
- `pytest -q` *(fails: Module errors and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_685969dacb288328bd9f92aae11936c7