### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -91,6 +91,21 @@ pip install -e .[test]
 pytest
 ```
 
+## 🛠️ Pre-commit Hooks
+
+Set up the pre-commit hooks to automatically format and lint code before each commit:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Run all hooks against the entire codebase with:
+
+```bash
+pre-commit run --all-files
+```
+
 ---
 
 ## 📊 Example Output


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` with hooks for `black`, `isort`, `flake8`, and `pytest`
- document how to install and run pre-commit

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml` *(fails: 28 failed, 113 passed)*
- `pytest -q` *(fails: 28 failed, 113 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686d64b8dcb4832890fc269026852778