### PR TITLE
Remove duplicate SARIF example

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,6 @@ ghast rules
 # Generate a comprehensive report
 ghast report /path/to/repo --output report.html
 
-# Generate SARIF output for GitHub Code Scanning
-ghast scan /path/to/repo --output sarif --output-file ghast-results.sarif
 ```
 
 ---


### PR DESCRIPTION
## Summary
- delete duplicate SARIF command example in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and test assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_686d64b5e48c8328ad978d0064dc8de1