### PR TITLE
Add config key validation

### DIFF
--- a/ghast/core/config.py
+++ b/ghast/core/config.py
@@ -132,15 +132,20 @@ def merge_configs(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, A
 
 
 def validate_config(config: Dict[str, Any]) -> None:
-    """
-    Validate configuration structure and values
+    """Validate configuration structure and values"""
 
-    Args:
-        config: Configuration dictionary to validate
+    allowed_sections = {
+        "severity_thresholds",
+        "auto_fix",
+        "report",
+        "default_timeout_minutes",
+        "default_action_versions",
+    }
 
-    Raises:
-        ConfigurationError: If configuration is invalid
-    """
+    # Check for unknown top-level keys in the provided config
+    for key in config.keys():
+        if key not in DEFAULT_CONFIG and key not in allowed_sections:
+            raise ConfigurationError(f"Unknown configuration option '{key}'")
 
     for rule_key in DEFAULT_CONFIG.keys():
         if (

--- a/ghast/tests/core/test_config.py
+++ b/ghast/tests/core/test_config.py
@@ -122,6 +122,14 @@ def test_validate_config_invalid_timeout():
         validate_config(invalid_config)
 
 
+def test_validate_config_unknown_key():
+    """Test that unknown config keys raise ConfigurationError."""
+    invalid_config = {"unknown_key": True}
+
+    with pytest.raises(ConfigurationError):
+        validate_config(invalid_config)
+
+
 def test_merge_configs():
     """Test merging configurations."""
     base_config = {


### PR DESCRIPTION
## Summary
- validate unknown keys when loading config
- test that unknown config keys raise `ConfigurationError`

## Testing
- `pytest ghast/tests/core/test_config.py::test_validate_config_unknown_key -q`
- `pytest -q` *(fails: test_fix_workflow_file, test_fix_repository, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688bfeddd0508328afacc92ec24ad856