### PR TITLE
Use click for safe file write errors

### DIFF
--- a/ghast/tests/utils/test_file_handler.py
+++ b/ghast/tests/utils/test_file_handler.py
@@ -234,9 +234,9 @@ def test_files_are_identical(temp_dir):
 
     file4 = os.path.join(temp_dir, "file4.txt")
     with open(file4, "w") as f:
-        f.write("different but same length")  # Same length as file3
+        f.write("same length entry")  # Same length as file3
 
-    assert len("different content") == len("different but same length")
+    assert len("different content") == len("same length entry")
     assert files_are_identical(file3, file4) is False
 
 
@@ -281,6 +281,8 @@ def test_get_modified_workflows(mock_repo, temp_dir):
     assert len(modified) == 0
 
     custom_backup = create_file_backup(test_workflow, suffix=".backup")
+    with open(test_workflow, "a") as f:
+        f.write("\n# Modified again\n")
     modified = get_modified_workflows(test_dir, backup_suffix=".backup")
     assert len(modified) > 0
 

--- a/ghast/utils/file_handler.py
+++ b/ghast/utils/file_handler.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 import hashlib
 import datetime
+import click
 
 
 def is_git_repository(path: str) -> bool:
@@ -170,7 +171,7 @@ def safe_write_file(file_path: str, content: str, create_backup: bool = True) ->
             if os.path.exists(temp_path):
                 os.unlink(temp_path)
     except Exception as e:
-        print(f"Error writing file: {e}")
+        click.echo(f"Error writing file: {e}", err=True)
 
         if backup_path and os.path.exists(backup_path):
             restore_from_backup(backup_path, file_path)


### PR DESCRIPTION
## Summary
- handle `safe_write_file` errors using `click.echo` rather than `print`
- fix tests verifying identical file handling and workflow backup detection

## Testing
- `pytest ghast/tests/utils/test_file_handler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688bfedcc81083289224119858e29df8