### PR TITLE
test: ensure interactive dry-run message

### DIFF
--- a/ghast/tests/test_cli.py
+++ b/ghast/tests/test_cli.py
@@ -204,6 +204,17 @@ def test_cli_fix_dry_run(cli_runner, patchable_workflow_file):
     assert "timeout-minutes" not in content  # Should not be fixed
 
 
+def test_cli_fix_interactive_dry_run(cli_runner, patchable_workflow_file):
+    """Test interactive flag with dry-run mode."""
+
+    result = cli_runner.invoke(
+        cli, ["fix", patchable_workflow_file, "--dry-run", "--interactive"]
+    )
+
+    assert result.exit_code == 0
+    assert "Note: --interactive has no effect in dry-run mode." in result.output
+
+
 def test_cli_fix_severity_threshold(cli_runner, patchable_workflow_file, temp_dir):
     """Test fixing with different severity thresholds."""
 


### PR DESCRIPTION
## Summary
- cover interactive dry-run informational message in CLI fix command

## Testing
- `PYTHONPATH=. pytest ghast/tests/test_cli.py::test_cli_fix_interactive_dry_run -vv`
- `PYTHONPATH=. pytest` *(fails: AttributeError: 'PermissionsRule' object has no attribute 'check_job_permissions', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688bfede74b0832883648c7237fc3652