### PR TITLE
Use SPDX license configuration to address build warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,16 @@ readme = "README.md"
 authors = [
     {name = "Sean Evans", email = "sean.w.evans@gmail.com"}
 ]
-license = {text = "MIT"}
+# Use an SPDX identifier for the license to avoid setuptools warnings during
+# builds and explicitly include the license file in the distribution.
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary
- use SPDX `MIT` license string and include license file to avoid setuptools build warnings
- drop deprecated license classifier

## Testing
- `python -m build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fb262773c8328a7b99d63aa90297e