### PR TITLE
Fix license declaration for packaging compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64.0.0", "wheel"]
+requires = ["setuptools>=69.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -12,7 +12,7 @@ authors = [
 ]
 # Use an SPDX identifier for the license to avoid setuptools warnings during
 # builds and explicitly include the license file in the distribution.
-license = "MIT"
+license = {text = "MIT"}
 license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary
- fix pyproject license field to use PEP 621 table format
- require newer setuptools to understand license table

## Testing
- `python -m pre_commit run --files pyproject.toml` *(fails: ModuleNotFoundError: No module named 'ghast')*


------
https://chatgpt.com/codex/tasks/task_e_689fb41c8be4832890f3b6c0b753d5bc