### PR TITLE
chore: align isort line length with Black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ include = '\.pyi?$'
 
 [tool.isort]
 profile = "black"
-line_length = 88
+line_length = 100
 
 [tool.mypy]
 python_version = "3.8"


### PR DESCRIPTION
## Summary
- align isort's line length with Black's configuration

## Testing
- `pre-commit run --all-files` *(fails: flake8 line length errors; pytest can't import `ghast`)*

------
https://chatgpt.com/codex/tasks/task_e_689fbb3d8ee48328957929c49561b76e