### PR TITLE
Use Python for pytest pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,5 +18,6 @@ repos:
       - id: pytest
         name: pytest
         entry: pytest
-        language: system
+        language: python
+        additional_dependencies: ["pytest>=7.0.0"]
         pass_filenames: false


### PR DESCRIPTION
## Summary
- run the `pytest` pre-commit hook in a Python environment
- ensure the hook installs `pytest>=7.0.0`

## Testing
- `pre-commit run pytest --all-files` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_689fbb3eac948328bdc5bdfb06db7314