### PR TITLE
chore: pin development tooling

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[test]"
-        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+        pip install -r requirements-dev.txt
       shell: bash
 
     - name: Run tests
@@ -74,7 +74,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black isort flake8 mypy types-PyYAML types-click
+        pip install -r requirements-dev.txt
         pip install -e .
       shell: bash
 
@@ -155,7 +155,7 @@ jobs:
     - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build wheel
+        pip install -r requirements-dev.txt
       shell: bash
 
     - name: Build package

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+black==25.1.0
+isort==6.0.1
+flake8==7.3.0
+mypy==1.17.1
+types-PyYAML==6.0.12.20250809
+types-click==7.1.8
+build==1.3.0
+wheel==0.45.1


### PR DESCRIPTION
## Summary
- pin dev dependency versions
- use requirements-dev.txt in CI

## Testing
- `python -m pip install -r requirements-dev.txt`
- `pip install pytest pytest-cov`
- `PYTHONPATH=$PWD pytest ghast/tests`


------
https://chatgpt.com/codex/tasks/task_e_689fbb3faccc8328a2f4dbe4a50cc8f1