### PR TITLE
Add Python 3.12 to CI and formatting config

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     # Set timeout to prevent hung jobs
     timeout-minutes: 15
@@ -37,7 +37,7 @@ jobs:
 
     # Setup Python with specific SHA commit pinning
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -66,7 +66,7 @@ jobs:
         persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.10'
         cache: 'pip'
@@ -111,7 +111,7 @@ jobs:
         persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.10'
         cache: 'pip'
@@ -147,7 +147,7 @@ jobs:
         persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.10'
         cache: 'pip'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ ghast = ["py.typed"]
 
 [tool.black]
 line-length = 100
-target-version = ["py38", "py39", "py310"]
+target-version = ["py38", "py39", "py310", "py311"]
 include = '\.pyi?$'
 
 [tool.isort]


### PR DESCRIPTION
## Summary
- include `py311` in Black target versions
- test on Python 3.12 and update `actions/setup-python` pin

## Testing
- `python -m pytest`
- `pre-commit run --files pyproject.toml .github/workflows/python-app.yml` *(fails: ModuleNotFoundError: No module named 'ghast')*


------
https://chatgpt.com/codex/tasks/task_e_689fbb409b38832884a10a2c652db6ec