### PR TITLE
Fix pyproject license-files location

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ authors = [
 # Use an SPDX identifier for the license to avoid setuptools warnings during
 # builds and explicitly include the license file in the distribution.
 license = {text = "MIT"}
-license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
@@ -64,6 +63,7 @@ ghast = "ghast:main"
 
 [tool.setuptools]
 packages = ["ghast"]
+license-files = ["LICENSE"]
 
 [tool.setuptools.package-data]
 ghast = ["py.typed"]


### PR DESCRIPTION
## Summary
- move license-files setting from project section to setuptools config

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fbeb758c8832886d1e6d247f6ea44