### PR TITLE
ci: auto-format code with black

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -54,12 +54,12 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       with:
-        persist-credentials: false
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -74,14 +74,24 @@ jobs:
         pip install -e .
       shell: bash
 
+    - name: Format code with black
+      run: |
+        black ghast
+      shell: bash
+
+    - name: Commit formatted code
+      run: |
+        if [[ -n "$(git status --porcelain)" ]]; then
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore: format code with black"
+          git push
+        fi
+      shell: bash
+
     - name: Lint with flake8
       run: |
         flake8 ghast --count --select=E9,F63,F7,F82 --show-source --statistics
-      shell: bash
-
-    - name: Check formatting with black
-      run: |
-        black --check ghast
       shell: bash
 
     - name: Check imports with isort


### PR DESCRIPTION
## Summary
- allow lint job to format code with Black and commit changes

## Testing
- `pre-commit run black --files .github/workflows/python-app.yml`
- `pre-commit run isort --files .github/workflows/python-app.yml`
- `pre-commit run flake8 --files .github/workflows/python-app.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fc2f7606c832882ad1e1e9efaafb6