### PR TITLE
Add type hints for YAML utilities and config

### DIFF
--- a/ghast/core/config.py
+++ b/ghast/core/config.py
@@ -6,8 +6,7 @@ This module handles loading, validating, and managing configuration for the ghas
 
 import os
 import yaml
-from typing import Dict, Any, Optional, List
-from pathlib import Path
+from typing import Any, Dict, Optional, List, cast
 
 DEFAULT_CONFIG = {
     "check_timeout": True,
@@ -282,7 +281,9 @@ def generate_default_config(output_path: Optional[str] = None) -> str:
     Raises:
         ConfigurationError: If configuration cannot be saved
     """
-    default_config_yaml = yaml.dump(DEFAULT_CONFIG, default_flow_style=False, sort_keys=False)
+    default_config_yaml = cast(
+        str, yaml.dump(DEFAULT_CONFIG, default_flow_style=False, sort_keys=False)
+    )
 
     if output_path:
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "isort>=5.0.0",
     "flake8>=5.0.0",
     "mypy>=0.9.0",
+    "types-PyYAML>=6.0.0",
 ]
 test = [
     "pytest>=7.0.0",
@@ -75,7 +76,7 @@ profile = "black"
 line_length = 100
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true


### PR DESCRIPTION
## Summary
- annotate YAML loader/dumper utilities and path resolution helpers
- cast YAML dump output in config generation
- include types-PyYAML and update mypy's Python target

## Testing
- `mypy ghast/utils/yaml_handler.py ghast/core/config.py --follow-imports=skip --ignore-missing-imports`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fcb6e41888328a2c587562931b6f7