### PR TITLE
Ignore tests in mypy configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
+exclude = ["ghast/tests"]
 
 [tool.pytest.ini_options]
 testpaths = ["ghast/tests"]


### PR DESCRIPTION
## Summary
- exclude `ghast/tests` from mypy analysis

## Testing
- `mypy ghast` *(fails: Library stubs not installed and many type annotation issues)*
- `mypy ghast/tests` *(skipped: There are no .py[i] files in directory 'ghast/tests')*
- `pytest`
- `pre-commit run --files pyproject.toml` *(fails: ModuleNotFoundError: No module named 'ghast')*

------
https://chatgpt.com/codex/tasks/task_e_689fcdcc823c8328906edbbbe5d59e71