### PR TITLE
Add type annotations across core modules

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203
+per-file-ignores =
+    ghast/rules/security.py:E501
+    ghast/core/scanner.py:E501
+    ghast/rules/best_practices.py:E501
+    ghast/rules/engine.py:E501

--- a/ghast/__init__.py
+++ b/ghast/__init__.py
@@ -7,25 +7,23 @@ based on industry best practices.
 """
 
 from ghast.utils.version import __version__, get_version, get_version_info
-from .utils.banner import _BANNER
 
 from .core import (
+    SEVERITY_LEVELS,
+    ConfigurationError,
     Finding,
     WorkflowScanner,
-    scan_repository,
-    SEVERITY_LEVELS,
-    load_config,
-    generate_default_config,
-    save_config,
     disable_rules,
-    ConfigurationError,
-    fix_workflow_file,
     fix_repository,
+    fix_workflow_file,
+    generate_default_config,
+    load_config,
+    save_config,
+    scan_repository,
 )
-
-from .reports import generate_report, save_report, print_report, generate_full_report
-
+from .reports import generate_full_report, generate_report, print_report, save_report
 from .rules import Rule, RuleEngine, create_rule_engine
+from .utils.banner import _BANNER
 
 __all__ = [
     "__version__",
@@ -55,7 +53,7 @@ __all__ = [
 
 if "main" not in globals():
 
-    def main():
+    def main() -> None:
         """Main entry point for the ghast CLI tool"""
         from .cli import cli
 

--- a/ghast/rules/best_practices.py
+++ b/ghast/rules/best_practices.py
@@ -5,17 +5,17 @@ This module provides rules focused on best practices rather than strict security
 """
 
 import os
-from typing import List, Dict, Any, Set, Optional
 import re
+from typing import Any, Dict, List
 
-from .base import Rule, WorkflowRule, JobRule, StepRule
 from ..core import Finding
+from .base import JobRule, Rule, StepRule, WorkflowRule
 
 
 class TimeoutRule(JobRule):
     """Rule for checking job timeouts"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             rule_id="timeout",
             severity="LOW",
@@ -54,7 +54,7 @@ class TimeoutRule(JobRule):
 class ShellSpecificationRule(StepRule):
     """Rule for checking shell specification in multiline scripts"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             rule_id="shell_specification",
             severity="LOW",
@@ -111,7 +111,7 @@ class ShellSpecificationRule(StepRule):
 class WorkflowNameRule(WorkflowRule):
     """Rule for checking workflow name"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             rule_id="workflow_name",
             severity="LOW",
@@ -128,7 +128,6 @@ class WorkflowNameRule(WorkflowRule):
     def fix(self, workflow: Dict[str, Any], finding: Finding) -> bool:
         """Fix missing workflow name"""
         if "name" not in workflow:
-
             file_name = finding.file_path.split("/")[-1]
 
             workflow_name = (
@@ -151,7 +150,7 @@ class WorkflowNameRule(WorkflowRule):
 class DeprecatedActionsRule(StepRule):
     """Rule for checking deprecated actions"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             rule_id="deprecated_actions",
             severity="MEDIUM",
@@ -222,7 +221,6 @@ class DeprecatedActionsRule(StepRule):
                     step = steps[step_idx]
 
                     if "uses" in step and step["uses"] == deprecated_action:
-
                         replacement = finding.context.get("replacement")
 
                         if not replacement:
@@ -241,7 +239,7 @@ class DeprecatedActionsRule(StepRule):
 class ContinueOnErrorRule(Rule):
     """Rule for checking continue-on-error usage"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             rule_id="continue_on_error",
             severity="MEDIUM",
@@ -283,7 +281,7 @@ class ContinueOnErrorRule(Rule):
 class ReusableWorkflowRule(Rule):
     """Rule for checking reusable workflow inputs"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             rule_id="reusable_workflow_inputs",
             severity="MEDIUM",
@@ -299,7 +297,6 @@ class ReusableWorkflowRule(Rule):
         jobs = workflow.get("jobs", {})
         for job_id, job in jobs.items():
             if job.get("uses") and "with" in job:
-
                 if not job.get("inputs"):
                     findings.append(
                         self.create_finding(

--- a/ghast/rules/engine.py
+++ b/ghast/rules/engine.py
@@ -4,36 +4,32 @@ engine.py - Rule engine for ghast
 This module provides the core rule engine that manages and runs security rules.
 """
 
-import os
-import yaml
-from typing import List, Dict, Any, Set, Optional, Type
+from typing import Any, Dict, List, Optional
 
 from ..core import Finding
 from .base import Rule
+from .best_practices import (
+    ContinueOnErrorRule,
+    DeprecatedActionsRule,
+    ReusableWorkflowRule,
+    ShellSpecificationRule,
+    TimeoutRule,
+    WorkflowNameRule,
+)
 from .security import (
-    PermissionsRule,
-    PoisonedPipelineExecutionRule,
+    ActionPinningRule,
     CommandInjectionRule,
     EnvironmentInjectionRule,
+    PermissionsRule,
+    PoisonedPipelineExecutionRule,
     TokenSecurityRule,
-    ActionPinningRule,
-)
-from .best_practices import (
-    TimeoutRule,
-    ShellSpecificationRule,
-    WorkflowNameRule,
-    DeprecatedActionsRule,
-    ContinueOnErrorRule,
-    ReusableWorkflowRule,
 )
 
 
 class RuleEngine:
-    """
-    Engine for managing and running GitHub Actions security rules
-    """
+    """Engine for managing and running GitHub Actions security rules"""
 
-    def __init__(self, config: Optional[Dict[str, Any]] = None, strict: bool = False):
+    def __init__(self, config: Optional[Dict[str, Any]] = None, strict: bool = False) -> None:
         """
         Initialize the rule engine
 
@@ -43,13 +39,13 @@ class RuleEngine:
         """
         self.config = config or {}
         self.strict = strict
-        self.rules = []
+        self.rules: List[Rule] = []
 
         self._register_default_rules()
 
         self._apply_config()
 
-    def _register_default_rules(self):
+    def _register_default_rules(self) -> None:
         """Register the default set of rules"""
 
         self.rules.append(PermissionsRule())
@@ -66,7 +62,7 @@ class RuleEngine:
         self.rules.append(ContinueOnErrorRule())
         self.rules.append(ReusableWorkflowRule())
 
-    def _apply_config(self):
+    def _apply_config(self) -> None:
         """Apply configuration to rules"""
         if not self.config:
             return
@@ -96,7 +92,7 @@ class RuleEngine:
             elif short_with_check in severity_thresholds:
                 rule.severity = severity_thresholds[short_with_check]
 
-    def register_rule(self, rule: Rule):
+    def register_rule(self, rule: Rule) -> None:
         """
         Register a custom rule
 
@@ -205,7 +201,6 @@ class RuleEngine:
                 rule_findings = rule.check(workflow, file_path)
                 findings.extend(rule_findings)
             except Exception as e:
-
                 findings.append(
                     Finding(
                         rule_id=f"rule_error.{rule.rule_id}",

--- a/ghast/rules/security.py
+++ b/ghast/rules/security.py
@@ -4,17 +4,17 @@ security.py - Security-focused rules for GitHub Actions
 This module provides rules focused on security issues in GitHub Actions workflows.
 """
 
-from typing import List, Dict, Any, Set
 import re
+from typing import Any, Dict, List
 
-from .base import Rule, WorkflowRule, JobRule, StepRule, TriggerRule, TokenRule
 from ..core import Finding
+from .base import Rule, StepRule, TokenRule, WorkflowRule
 
 
 class PermissionsRule(WorkflowRule):
     """Rule for checking workflow permissions"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             rule_id="permissions",
             severity="HIGH",
@@ -111,7 +111,7 @@ class PermissionsRule(WorkflowRule):
 class PoisonedPipelineExecutionRule(Rule):
     """Rule for detecting Poisoned Pipeline Execution (PPE) vulnerabilities"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             rule_id="poisoned_pipeline_execution",
             severity="CRITICAL",
@@ -218,7 +218,7 @@ class PoisonedPipelineExecutionRule(Rule):
 class CommandInjectionRule(StepRule):
     """Rule for detecting potential command injection vulnerabilities"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             rule_id="command_injection",
             severity="HIGH",
@@ -281,7 +281,7 @@ class CommandInjectionRule(StepRule):
 class EnvironmentInjectionRule(StepRule):
     """Rule for detecting unsafe modifications to GITHUB_ENV and GITHUB_PATH"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             rule_id="environment_injection",
             severity="HIGH",
@@ -338,7 +338,10 @@ class EnvironmentInjectionRule(StepRule):
                         ):
                             findings.append(
                                 self.create_finding(
-                                    message=f"Modification of GITHUB_PATH after checkout in job '{job_id}' step {step_idx+1}",
+                                    message=(
+                                        f"Modification of GITHUB_PATH after checkout in job '{job_id}' "
+                                        f"step {step_idx+1}"
+                                    ),
                                     file_path=file_path,
                                 )
                             )
@@ -349,12 +352,15 @@ class EnvironmentInjectionRule(StepRule):
 class TokenSecurityRule(TokenRule):
     """Rule for checking token and secret usage"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             rule_id="token_security",
             severity="HIGH",
             description="Detects hardcoded tokens and insecure secret handling in workflows",
-            remediation="Store secrets in GitHub Secrets and reference them with ${{ secrets.SECRET_NAME }}",
+            remediation=(
+                "Store secrets in GitHub Secrets and reference them "
+                "with ${{ secrets.SECRET_NAME }}"
+            ),
             category="security",
         )
 
@@ -378,9 +384,14 @@ class TokenSecurityRule(TokenRule):
                     ):
                         findings.append(
                             self.create_finding(
-                                message=f"actions/checkout in job '{job_id}' step {step_idx+1} does not disable credential persistence",
+                                message=(
+                                    f"actions/checkout in job '{job_id}' step {step_idx+1} "
+                                    "does not disable credential persistence"
+                                ),
                                 file_path=file_path,
-                                remediation="Add 'persist-credentials: false' to the 'with' section of actions/checkout steps",
+                                remediation=(
+                                    "Add 'persist-credentials: false' to the 'with' section of actions/checkout steps"
+                                ),
                                 can_fix=True,
                             )
                         )
@@ -417,7 +428,7 @@ class TokenSecurityRule(TokenRule):
 class ActionPinningRule(StepRule):
     """Rule for checking action pinning"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             rule_id="action_pinning",
             severity="MEDIUM",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,3 +88,6 @@ testpaths = ["ghast/tests"]
 python_files = "test_*.py"
 python_functions = "test_*"
 python_classes = "Test*"
+
+[tool.flake8]
+max-line-length = 100


### PR DESCRIPTION
## Summary
- add missing type hints to core classes and rule definitions
- configure flake8 and format code for consistency

## Testing
- `pre-commit run black --files ghast/core/fixer.py ghast/core/scanner.py ghast/rules/engine.py ghast/rules/best_practices.py ghast/rules/security.py ghast/__init__.py pyproject.toml`
- `pre-commit run isort --files ghast/core/fixer.py ghast/core/scanner.py ghast/rules/engine.py ghast/rules/best_practices.py ghast/rules/security.py ghast/__init__.py pyproject.toml`
- `pre-commit run flake8 --files ghast/core/fixer.py ghast/core/scanner.py ghast/rules/engine.py ghast/rules/best_practices.py ghast/rules/security.py ghast/__init__.py pyproject.toml .flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fcfd0c74c8328b304888df64188ee