### PR TITLE
Enhance typing for mypy compliance

### DIFF
--- a/ghast/core/fixer.py
+++ b/ghast/core/fixer.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Tuple, cast
 
 import click
 import yaml
-from yaml.nodes import Node
+from yaml.nodes import MappingNode, Node
 
 from .scanner import Finding
 
@@ -38,8 +38,12 @@ class SafeDumper(yaml.SafeDumper):
     pass
 
 
-def construct_mapping(self: "SafeLoader", node: Node, deep: bool = False) -> Dict[str, Any]:
-    mapping = cast(Dict[str, Any], super(SafeLoader, self).construct_mapping(node, deep=deep))
+def construct_mapping(
+    self: "SafeLoader", node: MappingNode, deep: bool = False
+) -> Dict[str, Any]:
+    mapping = cast(
+        Dict[str, Any], super(SafeLoader, self).construct_mapping(node, deep=deep)
+    )
     mapping["__line__"] = node.start_mark.line
     mapping["__column__"] = node.start_mark.column
     return mapping

--- a/ghast/reports/json.py
+++ b/ghast/reports/json.py
@@ -60,7 +60,7 @@ def generate_json_report(
 
     findings_data: List[Dict[str, Any]] = [finding_to_dict(finding) for finding in findings]
 
-    report = {
+    report: Dict[str, Any] = {
         "ghast_version": __version__,
         "generated_at": datetime.now().isoformat(),
         "findings": findings_data,


### PR DESCRIPTION
## Summary
- use MappingNode in fixer to satisfy SafeConstructor
- add explicit typing and casts throughout SARIF and JSON report generation
- annotate CLI stats collections and apply casts for safer dictionary access

## Testing
- `python -m mypy ghast`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689feb34807083288eb1f2711b1a826d