### PR TITLE
Refactor config validation helpers

### DIFF
--- a/ghast/core/config.py
+++ b/ghast/core/config.py
@@ -130,6 +130,56 @@ def merge_configs(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, A
     return result
 
 
+def _validate_severity_thresholds(config: Dict[str, Any]) -> None:
+    """Validate severity threshold configuration"""
+
+    valid_severities = ["LOW", "MEDIUM", "HIGH", "CRITICAL"]
+    if "severity_thresholds" in config:
+        if not isinstance(config["severity_thresholds"], dict):
+            raise ConfigurationError("'severity_thresholds' must be a dictionary")
+
+        for rule, severity in config["severity_thresholds"].items():
+            if severity not in valid_severities:
+                raise ConfigurationError(
+                    f"Invalid severity '{severity}' for rule '{rule}'. Must be one of: {', '.join(valid_severities)}"
+                )
+
+
+def _validate_auto_fix(config: Dict[str, Any]) -> None:
+    """Validate auto-fix configuration"""
+
+    if "auto_fix" in config:
+        if not isinstance(config["auto_fix"], dict):
+            raise ConfigurationError("'auto_fix' must be a dictionary")
+
+        if "enabled" in config["auto_fix"] and not isinstance(config["auto_fix"]["enabled"], bool):
+            raise ConfigurationError("'auto_fix.enabled' must be a boolean")
+
+        if "rules" in config["auto_fix"]:
+            if not isinstance(config["auto_fix"]["rules"], dict):
+                raise ConfigurationError("'auto_fix.rules' must be a dictionary")
+
+            for rule, enabled in config["auto_fix"]["rules"].items():
+                if not isinstance(enabled, bool):
+                    raise ConfigurationError(f"'auto_fix.rules.{rule}' must be a boolean")
+
+
+def _validate_defaults(config: Dict[str, Any]) -> None:
+    """Validate default configuration values"""
+
+    if "default_timeout_minutes" in config:
+        try:
+            timeout = int(config["default_timeout_minutes"])
+            if timeout <= 0:
+                raise ConfigurationError("'default_timeout_minutes' must be a positive integer")
+        except ValueError:
+            raise ConfigurationError("'default_timeout_minutes' must be a positive integer")
+
+    if "default_action_versions" in config:
+        if not isinstance(config["default_action_versions"], dict):
+            raise ConfigurationError("'default_action_versions' must be a dictionary")
+
+
 def validate_config(config: Dict[str, Any]) -> None:
     """Validate configuration structure and values"""
 
@@ -157,43 +207,9 @@ def validate_config(config: Dict[str, Any]) -> None:
             if rule_key in config and not isinstance(config[rule_key], bool):
                 raise ConfigurationError(f"Rule '{rule_key}' must be a boolean (true/false)")
 
-    valid_severities = ["LOW", "MEDIUM", "HIGH", "CRITICAL"]
-    if "severity_thresholds" in config:
-        if not isinstance(config["severity_thresholds"], dict):
-            raise ConfigurationError("'severity_thresholds' must be a dictionary")
-
-        for rule, severity in config["severity_thresholds"].items():
-            if severity not in valid_severities:
-                raise ConfigurationError(
-                    f"Invalid severity '{severity}' for rule '{rule}'. Must be one of: {', '.join(valid_severities)}"
-                )
-
-    if "auto_fix" in config:
-        if not isinstance(config["auto_fix"], dict):
-            raise ConfigurationError("'auto_fix' must be a dictionary")
-
-        if "enabled" in config["auto_fix"] and not isinstance(config["auto_fix"]["enabled"], bool):
-            raise ConfigurationError("'auto_fix.enabled' must be a boolean")
-
-        if "rules" in config["auto_fix"]:
-            if not isinstance(config["auto_fix"]["rules"], dict):
-                raise ConfigurationError("'auto_fix.rules' must be a dictionary")
-
-            for rule, enabled in config["auto_fix"]["rules"].items():
-                if not isinstance(enabled, bool):
-                    raise ConfigurationError(f"'auto_fix.rules.{rule}' must be a boolean")
-
-    if "default_timeout_minutes" in config:
-        try:
-            timeout = int(config["default_timeout_minutes"])
-            if timeout <= 0:
-                raise ConfigurationError("'default_timeout_minutes' must be a positive integer")
-        except ValueError:
-            raise ConfigurationError("'default_timeout_minutes' must be a positive integer")
-
-    if "default_action_versions" in config:
-        if not isinstance(config["default_action_versions"], dict):
-            raise ConfigurationError("'default_action_versions' must be a dictionary")
+    _validate_severity_thresholds(config)
+    _validate_auto_fix(config)
+    _validate_defaults(config)
 
 
 def load_config(config_path: Optional[str] = None) -> Dict[str, Any]:

--- a/ghast/tests/core/test_config.py
+++ b/ghast/tests/core/test_config.py
@@ -17,6 +17,9 @@ from ghast.core.config import (
     ConfigurationError,
     DEFAULT_CONFIG,
     disable_rules,
+    _validate_severity_thresholds,
+    _validate_auto_fix,
+    _validate_defaults,
 )
 
 
@@ -167,6 +170,36 @@ def test_generate_default_config():
     assert "check_timeout" in config
     assert "severity_thresholds" in config
     assert "auto_fix" in config
+
+
+def test_validate_severity_thresholds_helper():
+    """Test helper for validating severity thresholds."""
+    valid = {"severity_thresholds": {"check_timeout": "HIGH"}}
+    _validate_severity_thresholds(valid)
+
+    invalid = {"severity_thresholds": {"check_timeout": "INVALID"}}
+    with pytest.raises(ConfigurationError):
+        _validate_severity_thresholds(invalid)
+
+
+def test_validate_auto_fix_helper():
+    """Test helper for validating auto_fix section."""
+    valid = {"auto_fix": {"enabled": True, "rules": {"check_timeout": False}}}
+    _validate_auto_fix(valid)
+
+    invalid = {"auto_fix": {"rules": {"check_timeout": "yes"}}}
+    with pytest.raises(ConfigurationError):
+        _validate_auto_fix(invalid)
+
+
+def test_validate_defaults_helper():
+    """Test helper for validating default values."""
+    valid = {"default_timeout_minutes": 5, "default_action_versions": {}}
+    _validate_defaults(valid)
+
+    invalid = {"default_timeout_minutes": -1}
+    with pytest.raises(ConfigurationError):
+        _validate_defaults(invalid)
 
 
 def test_generate_default_config_to_file(temp_dir):


### PR DESCRIPTION
## Summary
- factor config validation logic into _validate_severity_thresholds, _validate_auto_fix, and _validate_defaults helpers
- simplify validate_config by delegating to the new helpers
- add unit tests for each helper function

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a269eadd1c83288183bf536514cb5c