### PR TITLE
Specify UTF-8 encoding for file operations

### DIFF
--- a/ghast/core/config.py
+++ b/ghast/core/config.py
@@ -216,7 +216,7 @@ def load_config(config_path: Optional[str] = None) -> Dict[str, Any]:
             raise ConfigurationError(f"Configuration file not found: {config_path}")
 
         try:
-            with open(config_path, "r") as f:
+            with open(config_path, "r", encoding="utf-8") as f:
                 user_config = yaml.safe_load(f)
 
             if user_config:
@@ -232,7 +232,7 @@ def load_config(config_path: Optional[str] = None) -> Dict[str, Any]:
         for path in get_config_paths():
             if os.path.exists(path):
                 try:
-                    with open(path, "r") as f:
+                    with open(path, "r", encoding="utf-8") as f:
                         user_config = yaml.safe_load(f)
 
                     if user_config:
@@ -262,7 +262,7 @@ def save_config(config: Dict[str, Any], config_path: str) -> None:
 
         os.makedirs(os.path.dirname(os.path.abspath(config_path)), exist_ok=True)
 
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(config, f, default_flow_style=False, sort_keys=False)
     except Exception as e:
         raise ConfigurationError(f"Error saving configuration: {e}")
@@ -290,7 +290,7 @@ def generate_default_config(output_path: Optional[str] = None) -> str:
 
             os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
 
-            with open(output_path, "w") as f:
+            with open(output_path, "w", encoding="utf-8") as f:
                 f.write(default_config_yaml)
         except Exception as e:
             raise ConfigurationError(f"Error saving default configuration: {e}")

--- a/ghast/core/fixer.py
+++ b/ghast/core/fixer.py
@@ -99,7 +99,7 @@ class Fixer:
         if not findings_by_rule:
             return 0, 0
 
-        with open(file_path, "r") as f:
+        with open(file_path, "r", encoding="utf-8") as f:
             workflow = yaml.load(f, Loader=SafeLoader)
 
         backup_path = f"{file_path}.bak"
@@ -141,7 +141,7 @@ class Fixer:
                         self.fixes_skipped += 1
 
             self._clean_workflow(workflow)
-            with open(file_path, "w") as f:
+            with open(file_path, "w", encoding="utf-8") as f:
                 yaml.dump(
                     workflow,
                     f,

--- a/ghast/core/scanner.py
+++ b/ghast/core/scanner.py
@@ -185,7 +185,7 @@ class WorkflowScanner:
         findings: List[Finding] = []
 
         try:
-            with open(file_path, "r") as f:
+            with open(file_path, "r", encoding="utf-8") as f:
                 content = yaml.safe_load(f)
 
             # Validate that the file appears to be a GitHub Actions workflow. If

--- a/ghast/reports/json.py
+++ b/ghast/reports/json.py
@@ -135,5 +135,5 @@ def save_json_report(
     """
     report = generate_json_report(findings, stats, include_stats)
 
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         f.write(report)

--- a/ghast/reports/report.py
+++ b/ghast/reports/report.py
@@ -115,7 +115,7 @@ def save_report(
         summary_only=summary_only,
     )
 
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         f.write(report)
 
 

--- a/ghast/reports/sarif.py
+++ b/ghast/reports/sarif.py
@@ -236,7 +236,7 @@ def save_sarif_report(
         tool_version=tool_version,
     )
 
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         f.write(report)
 
 
@@ -290,5 +290,5 @@ def generate_sarif_suppression_file(findings: List[Finding], output_path: str) -
         ],
     }
 
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         json.dump(suppressions_file, f, indent=2)

--- a/ghast/utils/file_handler.py
+++ b/ghast/utils/file_handler.py
@@ -161,7 +161,7 @@ def safe_write_file(file_path: str, content: str, create_backup: bool = True) ->
 
         fd, temp_path = tempfile.mkstemp(dir=os.path.dirname(os.path.abspath(file_path)))
         try:
-            with os.fdopen(fd, "w") as f:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(content)
 
             shutil.move(temp_path, file_path)

--- a/ghast/utils/yaml_handler.py
+++ b/ghast/utils/yaml_handler.py
@@ -89,7 +89,7 @@ def load_yaml_file_with_positions(file_path: str) -> Dict[str, Any]:
         FileNotFoundError: If file is not found
         yaml.YAMLError: If YAML parsing fails
     """
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         return load_yaml_with_positions(f.read())
 
 
@@ -214,7 +214,7 @@ def extract_line_from_file(file_path: str, line_number: int, context: int = 2) -
         return []
 
     try:
-        with open(file_path, "r") as f:
+        with open(file_path, "r", encoding="utf-8") as f:
             lines = f.readlines()
 
         start = max(0, line_number - 1 - context)


### PR DESCRIPTION
## Summary
- ensure all text file reads and writes use UTF-8 encoding
- apply encoding parameter across core, utility, and report modules

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a269d6b58c8328b35f2e3931d264b2