### PR TITLE
Use deepcopy for default config in CLI

### DIFF
--- a/ghast/cli.py
+++ b/ghast/cli.py
@@ -5,6 +5,7 @@ This module provides the command-line interface for the ghast tool,
 allowing users to scan GitHub Actions workflows for security issues.
 """
 
+import copy
 import json
 import os
 from pathlib import Path
@@ -65,7 +66,7 @@ def _prepare_scan(
             raise click.ClickException(f"Error loading config file: {e}")
 
     else:
-        config_data = config_default.copy() if config_default is not None else None
+        config_data = copy.deepcopy(config_default) if config_default is not None else None
 
     if disable:
         if config_data is None:


### PR DESCRIPTION
## Summary
- avoid mutating default config by deep copying before scans
- add missing import for deepcopy

## Testing
- `pre-commit run --files ghast/cli.py` *(fails: ModuleNotFoundError: No module named 'ghast')*

------
https://chatgpt.com/codex/tasks/task_e_68b1e5ad979883289a96421bdc1d5aba