### PR TITLE
Escape HTML report text content

### DIFF
--- a/ghast/reports/report.py
+++ b/ghast/reports/report.py
@@ -6,6 +6,7 @@ This module provides a unified interface for generating reports in different for
 
 import os
 import sys
+from html import escape
 from typing import Any, Dict, List, Optional
 
 from ..core import Finding
@@ -191,6 +192,7 @@ def generate_html_report(
     text_report = format_console_report(
         findings, stats, verbose=True, show_remediation=True, show_summary=True
     )
+    escaped_text_report = escape(text_report)
 
     html = f"""<!DOCTYPE html>
 <html>
@@ -298,7 +300,7 @@ def generate_html_report(
     </table>
 
     <h2>Findings</h2>
-    <pre>{text_report.replace('<', '&lt;').replace('>', '&gt;')}</pre>
+    <pre>{escaped_text_report}</pre>
 </body>
 </html>
 """

--- a/ghast/tests/reports/test_html.py
+++ b/ghast/tests/reports/test_html.py
@@ -27,3 +27,25 @@ def test_generate_html_report_basic():
     assert "<html>" in html
     assert "<body>" in html
     assert '<table class="summary-table">' in html
+
+
+def test_generate_html_report_escapes_ampersand():
+    """Ensure ampersands in the text report are escaped in HTML output."""
+    findings = [
+        Finding(
+            rule_id="amp_rule",
+            severity="LOW",
+            message="Value A & Value B",
+            file_path="workflow.yml",
+        )
+    ]
+    stats = {
+        "total_files": 1,
+        "total_findings": 1,
+        "severity_counts": {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 1},
+    }
+
+    html = generate_html_report(findings, stats)
+
+    assert "Value A &amp; Value B" in html
+    assert "Value A & Value B" not in html


### PR DESCRIPTION
## Summary
- HTML-escape the text report before embedding it in the generated HTML template
- Add a regression test to ensure ampersands render correctly in the HTML report output

## Testing
- PYTHONPATH=. pytest ghast/tests/reports/test_html.py


------
https://chatgpt.com/codex/tasks/task_e_68d82b9d0fa883288360294b00d782ae