### PR TITLE
Add action pinning scanner rule and tests

### DIFF
--- a/ghast/core/scanner.py
+++ b/ghast/core/scanner.py
@@ -127,6 +127,13 @@ class WorkflowScanner:
         )
 
         self.register_rule(
+            "check_action_pinning",
+            self.check_action_pinning,
+            severity=Severity.MEDIUM,
+            description="Detects GitHub Actions steps that are not pinned to a commit SHA",
+        )
+
+        self.register_rule(
             "check_runs_on",
             self.check_runs_on,
             severity=Severity.MEDIUM,
@@ -372,6 +379,58 @@ class WorkflowScanner:
                                     can_fix=True,
                                 )
                             )
+
+        return findings
+
+    def check_action_pinning(self, workflow: Dict[str, Any], file_path: str) -> List[Finding]:
+        """Check that actions are pinned to immutable commit SHAs."""
+
+        findings: List[Finding] = []
+        jobs = workflow.get("jobs", {})
+
+        for job_id, job in jobs.items():
+            if job_id in ("__line__", "__column__"):
+                continue
+
+            steps = job.get("steps", [])
+            for step_idx, step in enumerate(steps):
+                if not isinstance(step, dict) or "uses" not in step:
+                    continue
+
+                action = step["uses"]
+                line_number = step.get("__line__")
+                column_number = step.get("__column__")
+
+                if re.search(r"@(main|master)$", action):
+                    findings.append(
+                        Finding(
+                            rule_id="check_action_pinning",
+                            severity=Severity.HIGH,
+                            message=(
+                                f"Step {step_idx + 1} in job '{job_id}' uses unstable reference: {action}"
+                            ),
+                            file_path=file_path,
+                            line_number=line_number,
+                            column=column_number,
+                            remediation="Pin the action to a specific commit SHA",
+                            can_fix=False,
+                        )
+                    )
+                elif not re.search(r"@[0-9a-fA-F]{39,40}$", action):
+                    findings.append(
+                        Finding(
+                            rule_id="check_action_pinning",
+                            severity=Severity.MEDIUM,
+                            message=(
+                                f"Step {step_idx + 1} in job '{job_id}' is not pinned to a specific commit SHA: {action}"
+                            ),
+                            file_path=file_path,
+                            line_number=line_number,
+                            column=column_number,
+                            remediation="Pin the action to a specific commit SHA for better security",
+                            can_fix=False,
+                        )
+                    )
 
         return findings
 

--- a/ghast/tests/conftest.py
+++ b/ghast/tests/conftest.py
@@ -104,6 +104,26 @@ jobs:
 
 
 @pytest.fixture
+def action_pinning_workflow_content():
+    """Workflow containing a mix of pinned and unpinned actions."""
+
+    return """
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Unstable reference
+        uses: actions/checkout@main
+      - name: Tagged release
+        uses: actions/setup-python@v4
+      - name: Pinned checkout
+        uses: actions/checkout@0123456789abcdef0123456789abcdef01234567
+"""
+
+
+@pytest.fixture
 def token_workflow_content():
     """Workflow containing hardcoded and safe token usage."""
     return """
@@ -150,6 +170,19 @@ def patchable_workflow_file(temp_dir, patchable_workflow_content):
 
     workflow_file = workflows_dir / "patchable.yml"
     workflow_file.write_text(patchable_workflow_content)
+
+    return str(workflow_file)
+
+
+@pytest.fixture
+def action_pinning_workflow_file(temp_dir, action_pinning_workflow_content):
+    """Create a workflow file containing pinned and unpinned actions."""
+
+    workflows_dir = Path(temp_dir) / ".github" / "workflows"
+    workflows_dir.mkdir(parents=True, exist_ok=True)
+
+    workflow_file = workflows_dir / "action-pinning.yml"
+    workflow_file.write_text(action_pinning_workflow_content)
 
     return str(workflow_file)
 

--- a/ghast/tests/core/test_scanner.py
+++ b/ghast/tests/core/test_scanner.py
@@ -91,6 +91,28 @@ def test_check_deprecated(patchable_workflow_file):
     assert all(f.line_number is not None and f.column is not None for f in findings)
 
 
+def test_check_action_pinning(action_pinning_workflow_file):
+    """Test check_action_pinning rule."""
+
+    scanner = WorkflowScanner()
+    workflow = load_yaml_file_with_positions(action_pinning_workflow_file)
+
+    findings = scanner.check_action_pinning(workflow, action_pinning_workflow_file)
+
+    assert len(findings) == 2
+    assert all(f.rule_id == "check_action_pinning" for f in findings)
+
+    messages = {finding.message for finding in findings}
+    assert any("unstable reference" in message for message in messages)
+    assert any("not pinned" in message for message in messages)
+    assert all(f.line_number is not None and f.column is not None for f in findings)
+
+    severities = {finding.severity for finding in findings}
+    assert Severity.HIGH.value in severities
+    assert Severity.MEDIUM.value in severities
+    assert all("0123456789abcdef0123456789abcdef01234567" not in message for message in messages)
+
+
 def test_check_workflow_name(patchable_workflow_file):
     """Test check_workflow_name rule."""
     scanner = WorkflowScanner()


### PR DESCRIPTION
## Summary
- add a WorkflowScanner helper that flags GitHub Actions steps using unstable or non-SHA references
- register the new action pinning rule with default metadata
- cover pinned vs. unpinned actions via fixtures in the core scanner tests

## Testing
- PYTHONPATH=. pytest ghast/tests/core/test_scanner.py

------
https://chatgpt.com/codex/tasks/task_e_68d82b9e34588328a02514612b6cc833