### PR TITLE
Ensure load_config returns deep copy of default config

### DIFF
--- a/ghast/core/config.py
+++ b/ghast/core/config.py
@@ -4,6 +4,7 @@ config.py - Configuration management for ghast
 This module handles loading, validating, and managing configuration for the ghast tool.
 """
 
+import copy
 import os
 import yaml
 from typing import Any, Dict, Optional, List, cast
@@ -240,7 +241,7 @@ def load_config(config_path: Optional[str] = None) -> Dict[str, Any]:
     Raises:
         ConfigurationError: If configuration file is invalid
     """
-    config = DEFAULT_CONFIG.copy()
+    config = copy.deepcopy(DEFAULT_CONFIG)
 
     if config_path:
         if not os.path.exists(config_path):

--- a/ghast/tests/core/test_config.py
+++ b/ghast/tests/core/test_config.py
@@ -203,6 +203,17 @@ def test_validate_defaults_helper():
         _validate_defaults(invalid)
 
 
+def test_load_config_returns_deep_copy():
+    """Mutating a loaded config should not affect DEFAULT_CONFIG."""
+    config = load_config()
+
+    config["auto_fix"]["rules"]["check_timeout"] = False
+    config["severity_thresholds"]["check_timeout"] = Severity.CRITICAL
+
+    assert DEFAULT_CONFIG["auto_fix"]["rules"]["check_timeout"] is True
+    assert DEFAULT_CONFIG["severity_thresholds"]["check_timeout"] == Severity.LOW
+
+
 def test_generate_default_config_to_file(temp_dir):
     """Test generating default config to a file."""
     output_path = os.path.join(temp_dir, "output_config.yml")


### PR DESCRIPTION
## Summary
- use copy.deepcopy when seeding configurations from DEFAULT_CONFIG
- add a regression test that mutating a loaded config does not modify the defaults

## Testing
- PYTHONPATH=. pytest ghast/tests/core/test_config.py

------
https://chatgpt.com/codex/tasks/task_e_69020d1a8cf88328bab70e0816663c5f