### PR TITLE
Normalize severity values and apply consistently across scanner, config, CLI, and rule engine

### DIFF
--- a/ghast/cli.py
+++ b/ghast/cli.py
@@ -21,6 +21,7 @@ from .core import (
     load_config,
     scan_repository,
 )
+from .core.scanner import normalize_severity
 from .reports import generate_full_report, print_report, save_report
 from .rules import create_rule_engine
 from .utils.banner import _BANNER
@@ -55,6 +56,8 @@ def _prepare_scan(
         A tuple of (findings, stats, config_data) where config_data is the
         configuration dictionary used for scanning.
     """
+
+    severity_threshold = normalize_severity(severity_threshold)
 
     if config:
         config_path = Path(config)
@@ -207,7 +210,8 @@ def scan(
 
     from .core import SEVERITY_LEVELS
 
-    threshold_index = SEVERITY_LEVELS.index(severity_threshold)
+    normalized_threshold = normalize_severity(severity_threshold)
+    threshold_index = SEVERITY_LEVELS.index(normalized_threshold)
     sev_counts = cast(Dict[str, int], stats.get("severity_counts", {}))
     severe_findings = sum(sev_counts.get(lvl, 0) for lvl in SEVERITY_LEVELS[threshold_index:])
 

--- a/ghast/core/config.py
+++ b/ghast/core/config.py
@@ -9,7 +9,7 @@ import os
 import yaml
 from typing import Any, Dict, Optional, List, cast
 
-from .scanner import Severity
+from .scanner import Severity, normalize_severity
 
 DEFAULT_CONFIG = {
     "check_timeout": True,
@@ -153,8 +153,8 @@ def _validate_severity_thresholds(config: Dict[str, Any]) -> None:
 
         for rule, severity in list(config["severity_thresholds"].items()):
             try:
-                config["severity_thresholds"][rule] = Severity(severity)
-            except Exception:
+                config["severity_thresholds"][rule] = normalize_severity(severity)
+            except ValueError:
                 valid = ", ".join(level.value for level in Severity)
                 raise ConfigurationError(
                     f"Invalid severity '{severity}' for rule '{rule}'. Must be one of: {valid}"

--- a/ghast/core/scanner.py
+++ b/ghast/core/scanner.py
@@ -29,6 +29,18 @@ class Severity(Enum):
 SEVERITY_LEVELS = [level.value for level in Severity]
 
 
+def normalize_severity(value: Union[str, Severity]) -> str:
+    """Normalize severity values to canonical uppercase labels."""
+    if isinstance(value, Severity):
+        return value.value
+    if isinstance(value, str):
+        normalized = value.strip().upper()
+        if normalized in SEVERITY_LEVELS:
+            return normalized
+    valid = ", ".join(SEVERITY_LEVELS)
+    raise ValueError(f"Invalid severity level: {value}. Must be one of: {valid}")
+
+
 @dataclass
 class Finding:
     """Represents a security finding in a workflow file"""
@@ -45,10 +57,7 @@ class Finding:
 
     def __post_init__(self) -> None:
         """Validate severity level"""
-        if isinstance(self.severity, Severity):
-            self.severity = self.severity.value
-        if self.severity not in SEVERITY_LEVELS:
-            raise ValueError(f"Invalid severity level: {self.severity}")
+        self.severity = normalize_severity(self.severity)
 
 
 class WorkflowScanner:
@@ -217,6 +226,7 @@ class WorkflowScanner:
             List of findings
         """
         findings: List[Finding] = []
+        normalized_threshold = normalize_severity(severity_threshold)
 
         try:
             content = load_yaml_file_with_positions(file_path)
@@ -232,8 +242,8 @@ class WorkflowScanner:
                 if not rule_info["enabled"]:
                     continue
 
-                rule_severity = rule_info["severity"]
-                if SEVERITY_LEVELS.index(rule_severity) < SEVERITY_LEVELS.index(severity_threshold):
+                rule_severity = normalize_severity(rule_info["severity"])
+                if SEVERITY_LEVELS.index(rule_severity) < SEVERITY_LEVELS.index(normalized_threshold):
                     continue
 
                 try:

--- a/ghast/rules/engine.py
+++ b/ghast/rules/engine.py
@@ -7,7 +7,7 @@ This module provides the core rule engine that manages and runs security rules.
 from typing import Any, Dict, List, Optional
 
 from ..core import SEVERITY_LEVELS, Finding
-from ..core.scanner import Severity
+from ..core.scanner import Severity, normalize_severity
 from .base import Rule
 from .best_practices import (
     ContinueOnErrorRule,
@@ -96,9 +96,7 @@ class RuleEngine:
                 value = None
 
             if value is not None:
-                if isinstance(value, Severity):
-                    value = value.value
-                rule.severity = value
+                rule.severity = normalize_severity(value)
 
     def register_rule(self, rule: Rule) -> None:
         """
@@ -201,19 +199,13 @@ class RuleEngine:
 
         normalized_threshold: Optional[str] = None
         if severity_threshold is not None:
-            normalized_threshold = (
-                severity_threshold.value
-                if isinstance(severity_threshold, Severity)
-                else severity_threshold
-            )
+            normalized_threshold = normalize_severity(severity_threshold)
 
         for rule in self.rules:
             if not rule.enabled:
                 continue
 
-            rule_severity = (
-                rule.severity.value if isinstance(rule.severity, Severity) else rule.severity
-            )
+            rule_severity = normalize_severity(rule.severity)
 
             if normalized_threshold and (
                 SEVERITY_LEVELS.index(rule_severity) < SEVERITY_LEVELS.index(normalized_threshold)

--- a/ghast/tests/core/test_config.py
+++ b/ghast/tests/core/test_config.py
@@ -60,7 +60,7 @@ def test_load_config_with_path(temp_dir):
 
     assert config["check_timeout"] is False
     assert config["check_shell"] is True
-    assert config["severity_thresholds"]["check_deprecated"] == Severity.HIGH
+    assert config["severity_thresholds"]["check_deprecated"] == "HIGH"
 
     assert "default_timeout_minutes" in config
 
@@ -203,6 +203,11 @@ def test_validate_severity_thresholds_helper():
     """Test helper for validating severity thresholds."""
     valid = {"severity_thresholds": {"check_timeout": "HIGH"}}
     _validate_severity_thresholds(valid)
+    assert valid["severity_thresholds"]["check_timeout"] == "HIGH"
+
+    mixed_case = {"severity_thresholds": {"check_timeout": "mEdIuM"}}
+    _validate_severity_thresholds(mixed_case)
+    assert mixed_case["severity_thresholds"]["check_timeout"] == "MEDIUM"
 
     invalid = {"severity_thresholds": {"check_timeout": "INVALID"}}
     with pytest.raises(ConfigurationError):

--- a/ghast/tests/rules/test_engine.py
+++ b/ghast/tests/rules/test_engine.py
@@ -155,6 +155,28 @@ def test_scan_workflow_with_severity_threshold(patchable_workflow_file):
     assert all(finding.severity != "LOW" for finding in findings)
 
 
+def test_scan_workflow_with_mixed_case_severity_threshold(patchable_workflow_file):
+    """Mixed-case severity thresholds should be normalized."""
+    with open(patchable_workflow_file, "r") as f:
+        workflow = yaml.safe_load(f)
+
+    engine = RuleEngine()
+    findings = engine.scan_workflow(workflow, patchable_workflow_file, severity_threshold="mEdIuM")
+
+    assert all(finding.severity != "LOW" for finding in findings)
+
+
+def test_scan_workflow_with_invalid_severity_threshold_raises(patchable_workflow_file):
+    """Invalid severity threshold values should raise an error."""
+    with open(patchable_workflow_file, "r") as f:
+        workflow = yaml.safe_load(f)
+
+    engine = RuleEngine()
+
+    with pytest.raises(ValueError):
+        engine.scan_workflow(workflow, patchable_workflow_file, severity_threshold="urgent")
+
+
 def test_scan_workflow_with_enum_severity_config(patchable_workflow_file):
     """Ensure enum severities in config are handled and filtering uses strings."""
 


### PR DESCRIPTION
### Motivation
- Ensure severity handling is consistent across the codebase so mixed-case or enum inputs behave predictably.
- Accept either `Severity` enum or string inputs and canonicalize to the uppercase labels `LOW|MEDIUM|HIGH|CRITICAL`.
- Fail fast for invalid severity values during config parsing or explicit scan calls to avoid silent mis-filtering.

### Description
- Added `normalize_severity(value)` to `ghast/core/scanner.py` which accepts `Severity` or string and returns canonical uppercase labels or raises `ValueError` on invalid input.
- Updated `Finding.__post_init__` to use `normalize_severity` so all findings store normalized severity strings. (`ghast/core/scanner.py`)
- Normalized severity handling in `WorkflowScanner.scan_file` by normalizing the incoming `severity_threshold` and per-rule severities before comparison. (`ghast/core/scanner.py`)
- Updated `_validate_severity_thresholds` to normalize and validate configured thresholds and raise `ConfigurationError` for invalid values. (`ghast/core/config.py`)
- Applied normalization when applying config values and when filtering by threshold in the rule engine. (`ghast/rules/engine.py`)
- Normalized CLI-provided `severity_threshold` early in `_prepare_scan` and when computing severe-finding exit behavior. (`ghast/cli.py`)
- Added/updated tests to cover mixed-case inputs and invalid strings in `ghast/tests/core/test_config.py` and `ghast/tests/rules/test_engine.py`.

### Testing
- Ran targeted tests with the repository on PYTHONPATH: `PYTHONPATH=/workspace/Ghast pytest -q ghast/tests/core/test_config.py ghast/tests/rules/test_engine.py` which passed (`40 passed`).
- Running plain `pytest` in an environment without the project on `PYTHONPATH` produced an import error (`ModuleNotFoundError: No module named 'ghast'`) during collection due to test runner environment configuration, not code regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6734b841c8328aac7ac9732d9bae0)