### PR TITLE
Suggest likely keys for unknown config options in validate_config

### DIFF
--- a/ghast/core/config.py
+++ b/ghast/core/config.py
@@ -5,6 +5,7 @@ This module handles loading, validating, and managing configuration for the ghas
 """
 
 import copy
+import difflib
 import os
 import yaml
 from typing import Any, Dict, Optional, List, cast
@@ -207,10 +208,19 @@ def validate_config(config: Dict[str, Any]) -> None:
         "default_action_versions",
     }
 
+    allowed_keys = set(DEFAULT_CONFIG.keys()) | allowed_sections
+
     # Check for unknown top-level keys in the provided config
     for key in config.keys():
-        if key not in DEFAULT_CONFIG and key not in allowed_sections:
-            raise ConfigurationError(f"Unknown configuration option '{key}'")
+        if key not in allowed_keys:
+            suggestions = difflib.get_close_matches(key, sorted(allowed_keys), n=3, cutoff=0.5)
+
+            message = f"Unknown configuration option '{key}'."
+            if suggestions:
+                message += f" Did you mean: {', '.join(suggestions)}?"
+            message += " See examples/ghast.yml for supported options."
+
+            raise ConfigurationError(message)
 
     for rule_key in DEFAULT_CONFIG.keys():
         if (

--- a/ghast/tests/core/test_config.py
+++ b/ghast/tests/core/test_config.py
@@ -160,6 +160,22 @@ def test_validate_config_unknown_key():
         validate_config(invalid_config)
 
 
+def test_validate_config_unknown_key_with_suggestion():
+    """Test unknown key error includes likely intended keys."""
+    invalid_config = {"check_timeot": True}
+
+    with pytest.raises(ConfigurationError, match=r"Did you mean: .*check_timeout"):
+        validate_config(invalid_config)
+
+
+def test_validate_config_unknown_key_without_suggestion():
+    """Test unknown key error still references sample config when no suggestions exist."""
+    invalid_config = {"zzzzzzzzzz": True}
+
+    with pytest.raises(ConfigurationError, match="examples/ghast.yml"):
+        validate_config(invalid_config)
+
+
 def test_merge_configs():
     """Test merging configurations."""
     base_config = {


### PR DESCRIPTION
### Motivation
- Improve the UX of configuration validation by providing actionable errors for unknown top-level keys so users can quickly correct typos.

### Description
- In `ghast/core/config.py` import `difflib` and build `allowed_keys` as `set(DEFAULT_CONFIG.keys()) | allowed_sections` to consolidate supported keys.
- When an unknown top-level key is encountered compute up to three fuzzy matches with `difflib.get_close_matches` and include them in the error message if present.
- Raise `ConfigurationError` with the unknown key, optional top 1–3 suggestions, and a pointer to `examples/ghast.yml` for reference.
- Add tests in `ghast/tests/core/test_config.py` covering typo suggestions (`check_timeot`) and no-suggestion cases (`zzzzzzzzzz`).

### Testing
- Ran `pytest -q ghast/tests/core/test_config.py` which initially failed in this environment due to an import path (`ModuleNotFoundError`), then reran with `PYTHONPATH=. pytest -q ghast/tests/core/test_config.py` and all tests passed (26 tests).
- The new tests `test_validate_config_unknown_key_with_suggestion` and `test_validate_config_unknown_key_without_suggestion` are included and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f673512df4832886f25fe2efcf3535)