### PR TITLE
Centralize YAML position tracking and update scanner to use `get_position`

### DIFF
--- a/ghast/core/scanner.py
+++ b/ghast/core/scanner.py
@@ -14,7 +14,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import yaml
 
-from ..utils.yaml_handler import load_yaml_file_with_positions
+from ..utils.yaml_handler import get_position, load_yaml_file_with_positions
 
 
 class Severity(Enum):
@@ -295,8 +295,6 @@ class WorkflowScanner:
 
         jobs = workflow.get("jobs", {})
         for job_id, job in jobs.items():
-            if job_id in ("__line__", "__column__"):
-                continue
             steps = job.get("steps", [])
 
             # Count individual commands within multiline run steps to better
@@ -319,8 +317,8 @@ class WorkflowScanner:
                         severity=Severity.LOW,
                         message=f"Job '{job_id}' has {step_count} steps but no timeout-minutes set",
                         file_path=file_path,
-                        line_number=job.get("__line__"),
-                        column=job.get("__column__"),
+                        line_number=get_position(job)[0],
+                        column=get_position(job)[1],
                         remediation=f"Add 'timeout-minutes: 15' to job '{job_id}'",
                         can_fix=True,
                     )
@@ -343,8 +341,8 @@ class WorkflowScanner:
                     severity=Severity.HIGH,
                     message="Missing explicit permissions at workflow level",
                     file_path=file_path,
-                    line_number=workflow.get("__line__"),
-                    column=workflow.get("__column__"),
+                    line_number=get_position(workflow)[0],
+                    column=get_position(workflow)[1],
                     remediation=remediation_workflow,
                     can_fix=True,
                 )
@@ -356,8 +354,8 @@ class WorkflowScanner:
                     severity=Severity.HIGH,
                     message="Overly permissive workflow permissions (write-all)",
                     file_path=file_path,
-                    line_number=workflow.get("__line__"),
-                    column=workflow.get("__column__"),
+                    line_number=get_position(workflow)[0],
+                    column=get_position(workflow)[1],
                     remediation=remediation_workflow,
                 )
             )
@@ -368,9 +366,6 @@ class WorkflowScanner:
 
         jobs = workflow.get("jobs", {})
         for job_id, job in jobs.items():
-            if job_id in ("__line__", "__column__"):
-                continue
-
             permissions = job.get("permissions")
             if permissions is None:
                 findings.append(
@@ -379,8 +374,8 @@ class WorkflowScanner:
                         severity=Severity.HIGH,
                         message=f"Missing explicit permissions in job '{job_id}'",
                         file_path=file_path,
-                        line_number=job.get("__line__"),
-                        column=job.get("__column__"),
+                        line_number=get_position(job)[0],
+                        column=get_position(job)[1],
                         remediation=remediation_job_template.format(job_id=job_id),
                         can_fix=True,
                     )
@@ -392,8 +387,8 @@ class WorkflowScanner:
                         severity=Severity.HIGH,
                         message=f"Job '{job_id}' has overly permissive permissions (write-all)",
                         file_path=file_path,
-                        line_number=job.get("__line__"),
-                        column=job.get("__column__"),
+                        line_number=get_position(job)[0],
+                        column=get_position(job)[1],
                         remediation=remediation_job_template.format(job_id=job_id),
                     )
                 )
@@ -406,8 +401,6 @@ class WorkflowScanner:
 
         jobs = workflow.get("jobs", {})
         for job_id, job in jobs.items():
-            if job_id in ("__line__", "__column__"):
-                continue
             steps = job.get("steps", [])
             for step_idx, step in enumerate(steps):
                 if isinstance(step, dict) and "run" in step and isinstance(step["run"], str):
@@ -418,8 +411,8 @@ class WorkflowScanner:
                                 severity=Severity.LOW,
                                 message=f"Multiline script in job '{job_id}' step {step_idx+1} has no shell specified",
                                 file_path=file_path,
-                                line_number=step.get("__line__"),
-                                column=step.get("__column__"),
+                                line_number=get_position(step)[0],
+                                column=get_position(step)[1],
                                 remediation="Add 'shell: bash' to this step",
                                 can_fix=True,
                             )
@@ -439,8 +432,6 @@ class WorkflowScanner:
 
         jobs = workflow.get("jobs", {})
         for job_id, job in jobs.items():
-            if job_id in ("__line__", "__column__"):
-                continue
             steps = job.get("steps", [])
             for step_idx, step in enumerate(steps):
                 if isinstance(step, dict) and "uses" in step:
@@ -452,8 +443,8 @@ class WorkflowScanner:
                                     severity=Severity.MEDIUM,
                                     message=f"Deprecated action '{step['uses']}' in job '{job_id}' step {step_idx+1}",
                                     file_path=file_path,
-                                    line_number=step.get("__line__"),
-                                    column=step.get("__column__"),
+                                    line_number=get_position(step)[0],
+                                    column=get_position(step)[1],
                                     remediation=recommendation,
                                     can_fix=True,
                                 )
@@ -468,17 +459,13 @@ class WorkflowScanner:
         jobs = workflow.get("jobs", {})
 
         for job_id, job in jobs.items():
-            if job_id in ("__line__", "__column__"):
-                continue
-
             steps = job.get("steps", [])
             for step_idx, step in enumerate(steps):
                 if not isinstance(step, dict) or "uses" not in step:
                     continue
 
                 action = step["uses"]
-                line_number = step.get("__line__")
-                column_number = step.get("__column__")
+                line_number, column_number = get_position(step)
 
                 if re.search(r"@(main|master)$", action):
                     findings.append(
@@ -519,8 +506,6 @@ class WorkflowScanner:
 
         jobs = workflow.get("jobs", {})
         for job_id, job in jobs.items():
-            if job_id in ("__line__", "__column__"):
-                continue
             runs_on = job.get("runs-on", "")
 
             if not runs_on:
@@ -530,8 +515,8 @@ class WorkflowScanner:
                         severity=Severity.MEDIUM,
                         message=f"Missing 'runs-on' in job '{job_id}'",
                         file_path=file_path,
-                        line_number=job.get("__line__"),
-                        column=job.get("__column__"),
+                        line_number=get_position(job)[0],
+                        column=get_position(job)[1],
                         remediation="Specify a runner, e.g., 'runs-on: ubuntu-latest'",
                         can_fix=True,
                     )
@@ -543,8 +528,8 @@ class WorkflowScanner:
                         severity=Severity.MEDIUM,
                         message=f"Job '{job_id}' uses self-hosted runner without labels",
                         file_path=file_path,
-                        line_number=job.get("__line__"),
-                        column=job.get("__column__"),
+                        line_number=get_position(job)[0],
+                        column=get_position(job)[1],
                         remediation="Add specific labels to self-hosted runners for better security isolation",
                         can_fix=False,
                     )
@@ -556,8 +541,8 @@ class WorkflowScanner:
                         severity=Severity.LOW if len(runs_on) > 1 else Severity.MEDIUM,
                         message=f"Job '{job_id}' uses self-hosted runner",
                         file_path=file_path,
-                        line_number=job.get("__line__"),
-                        column=job.get("__column__"),
+                        line_number=get_position(job)[0],
+                        column=get_position(job)[1],
                         remediation="Consider using GitHub-hosted runners for better security isolation",
                         can_fix=False,
                     )
@@ -589,8 +574,6 @@ class WorkflowScanner:
 
         jobs = workflow.get("jobs", {})
         for job_id, job in jobs.items():
-            if job_id in ("__line__", "__column__"):
-                continue
             if job.get("continue-on-error") is True:
                 findings.append(
                     Finding(
@@ -598,8 +581,8 @@ class WorkflowScanner:
                         severity=Severity.MEDIUM,
                         message=f"Job '{job_id}' has 'continue-on-error: true'",
                         file_path=file_path,
-                        line_number=job.get("__line__"),
-                        column=job.get("__column__"),
+                        line_number=get_position(job)[0],
+                        column=get_position(job)[1],
                         remediation="Remove 'continue-on-error' or set to false to ensure workflow fails on error",
                         can_fix=False,
                     )
@@ -614,8 +597,8 @@ class WorkflowScanner:
                             severity=Severity.MEDIUM,
                             message=f"Step {step_idx+1} in job '{job_id}' has 'continue-on-error: true'",
                             file_path=file_path,
-                            line_number=step.get("__line__"),
-                            column=step.get("__column__"),
+                            line_number=get_position(step)[0],
+                            column=get_position(step)[1],
                             remediation="Remove 'continue-on-error' or set to false to ensure workflow fails on error",
                             can_fix=False,
                         )
@@ -651,24 +634,22 @@ class WorkflowScanner:
 
         def walk(node: Any, line: Optional[int] = None, column: Optional[int] = None) -> None:
             if isinstance(node, dict):
-                current_line = node.get("__line__", line)
-                current_column = node.get("__column__", column)
+                current_line, current_column = get_position(node)
+                current_line = current_line if current_line is not None else line
+                current_column = current_column if current_column is not None else column
                 for key, value in node.items():
-                    if key in ("__line__", "__column__"):
-                        continue
-                    value_line = getattr(value, "__line__", None)
-                    value_column = getattr(value, "__column__", None)
+                    value_line, value_column = get_position(value)
                     walk(
                         value,
                         value_line if value_line is not None else current_line,
                         value_column if value_column is not None else current_column,
                     )
             elif isinstance(node, list):
-                current_line = getattr(node, "__line__", line)
-                current_column = getattr(node, "__column__", column)
+                current_line, current_column = get_position(node)
+                current_line = current_line if current_line is not None else line
+                current_column = current_column if current_column is not None else column
                 for item in node:
-                    item_line = getattr(item, "__line__", None)
-                    item_column = getattr(item, "__column__", None)
+                    item_line, item_column = get_position(item)
                     walk(
                         item,
                         item_line if item_line is not None else current_line,
@@ -732,9 +713,7 @@ class WorkflowScanner:
 
         if isinstance(inputs_section, dict):
             for input_name in inputs_section:
-                if input_name in ("__line__", "__column__"):
-                    continue
-                defined_inputs.add(str(input_name))
+                                defined_inputs.add(str(input_name))
         else:
             inputs_section = None
 
@@ -746,24 +725,22 @@ class WorkflowScanner:
 
         def walk(node: Any, line: Optional[int], column: Optional[int]) -> None:
             if isinstance(node, dict):
-                current_line = node.get("__line__", line)
-                current_column = node.get("__column__", column)
+                current_line, current_column = get_position(node)
+                current_line = current_line if current_line is not None else line
+                current_column = current_column if current_column is not None else column
                 for key, value in node.items():
-                    if key in ("__line__", "__column__"):
-                        continue
-                    value_line = getattr(value, "__line__", None)
-                    value_column = getattr(value, "__column__", None)
+                    value_line, value_column = get_position(value)
                     walk(
                         value,
                         value_line if value_line is not None else current_line,
                         value_column if value_column is not None else current_column,
                     )
             elif isinstance(node, list):
-                current_line = getattr(node, "__line__", line)
-                current_column = getattr(node, "__column__", column)
+                current_line, current_column = get_position(node)
+                current_line = current_line if current_line is not None else line
+                current_column = current_column if current_column is not None else column
                 for item in node:
-                    item_line = getattr(item, "__line__", None)
-                    item_column = getattr(item, "__column__", None)
+                    item_line, item_column = get_position(item)
                     walk(
                         item,
                         item_line if item_line is not None else current_line,
@@ -776,10 +753,9 @@ class WorkflowScanner:
                     references.add((match.group(1), line, column))
 
         for job_id, job in jobs.items():
-            if job_id in ("__line__", "__column__"):
-                continue
             if isinstance(job, dict):
-                walk(job, job.get("__line__"), job.get("__column__"))
+                _line, _col = get_position(job)
+                walk(job, _line, _col)
 
         if not references:
             return findings
@@ -827,8 +803,6 @@ class WorkflowScanner:
 
         jobs = workflow.get("jobs", {})
         for job_id, job in jobs.items():
-            if job_id in ("__line__", "__column__"):
-                continue
             steps = job.get("steps", [])
 
             checkout_found = False
@@ -865,8 +839,8 @@ class WorkflowScanner:
                         severity=Severity.CRITICAL,
                         message=f"Poisoned Pipeline Execution vulnerability: job '{job_id}' uses {', '.join(high_risk_triggers_used)} trigger with checkout of untrusted code",
                         file_path=file_path,
-                        line_number=job.get("__line__"),
-                        column=job.get("__column__"),
+                        line_number=get_position(job)[0],
+                        column=get_position(job)[1],
                         remediation="Use pull_request trigger instead, or if pull_request_target is required, do not check out untrusted code or use dedicated jobs with restricted permissions.",
                         can_fix=False,
                         context={
@@ -883,8 +857,8 @@ class WorkflowScanner:
                         severity=Severity.CRITICAL,
                         message=f"High-risk secret exposure: job '{job_id}' uses 'secrets: inherit' with {', '.join(high_risk_triggers_used)} trigger",
                         file_path=file_path,
-                        line_number=job.get("__line__"),
-                        column=job.get("__column__"),
+                        line_number=get_position(job)[0],
+                        column=get_position(job)[1],
                         remediation="Explicitly pass only required secrets to jobs, or use 'repositories' field to restrict which repos can use this workflow",
                         can_fix=False,
                         context={"triggers": list(high_risk_triggers_used)},
@@ -924,8 +898,6 @@ class WorkflowScanner:
 
         jobs = workflow.get("jobs", {})
         for job_id, job in jobs.items():
-            if job_id in ("__line__", "__column__"):
-                continue
             steps = job.get("steps", [])
             for step_idx, step in enumerate(steps):
                 if isinstance(step, dict) and "run" in step and isinstance(step["run"], str):
@@ -939,8 +911,8 @@ class WorkflowScanner:
                                     severity=Severity.HIGH,
                                     message=f"{desc} in job '{job_id}' step {step_idx+1}",
                                     file_path=file_path,
-                                    line_number=step.get("__line__"),
-                                    column=step.get("__column__"),
+                                    line_number=get_position(step)[0],
+                                    column=get_position(step)[1],
                                     remediation="Never use untrusted input directly in shell commands. Use input validation or environment variables with proper quoting.",
                                     can_fix=False,
                                 )
@@ -954,8 +926,8 @@ class WorkflowScanner:
                                     severity=Severity.MEDIUM,
                                     message=f"Environment variable interpolation in shell command in job '{job_id}' step {step_idx+1}",
                                     file_path=file_path,
-                                    line_number=step.get("__line__"),
-                                    column=step.get("__column__"),
+                                    line_number=get_position(step)[0],
+                                    column=get_position(step)[1],
                                     remediation="Be careful with environment variable interpolation in shell commands. Consider using proper quoting.",
                                     can_fix=False,
                                 )
@@ -969,8 +941,6 @@ class WorkflowScanner:
 
         jobs = workflow.get("jobs", {})
         for job_id, job in jobs.items():
-            if job_id in ("__line__", "__column__"):
-                continue
             steps = job.get("steps", [])
 
             checkout_step_idx = None
@@ -1002,8 +972,8 @@ class WorkflowScanner:
                                     severity=Severity.HIGH,
                                     message=f"Modification of GITHUB_ENV after checkout in job '{job_id}' step {step_idx+1}",
                                     file_path=file_path,
-                                    line_number=step.get("__line__"),
-                                    column=step.get("__column__"),
+                                    line_number=get_position(step)[0],
+                                    column=get_position(step)[1],
                                     remediation="Avoid modifying GITHUB_ENV after checking out untrusted code, or move environment settings before checkout.",
                                     can_fix=False,
                                 )
@@ -1020,8 +990,8 @@ class WorkflowScanner:
                                     severity=Severity.HIGH,
                                     message=f"Modification of GITHUB_PATH after checkout in job '{job_id}' step {step_idx+1}",
                                     file_path=file_path,
-                                    line_number=step.get("__line__"),
-                                    column=step.get("__column__"),
+                                    line_number=get_position(step)[0],
+                                    column=get_position(step)[1],
                                     remediation="Avoid modifying GITHUB_PATH after checking out untrusted code, or move path modifications before checkout.",
                                     can_fix=False,
                                 )

--- a/ghast/tests/core/test_scanner.py
+++ b/ghast/tests/core/test_scanner.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from ghast.core import WorkflowScanner, Finding, scan_repository, SEVERITY_LEVELS
 from ghast.core.scanner import Severity
-from ghast.utils import load_yaml_file_with_positions
+from ghast.utils import get_position, load_yaml_file_with_positions
 
 import pytest
 
@@ -150,8 +150,8 @@ def test_check_tokens(token_workflow_file):
     assert any("toJson(secrets)" in m for m in messages)
 
     steps = workflow["jobs"]["build"]["steps"]
-    token_line = steps[0]["__line__"]
-    tojson_line = steps[2]["__line__"]
+    token_line = get_position(steps[0])[0]
+    tojson_line = get_position(steps[2])[0]
     token_finding = next(f for f in findings if "Hardcoded token" in f.message)
     tojson_finding = next(f for f in findings if "toJson(secrets)" in f.message)
     assert token_finding.line_number == token_line
@@ -232,7 +232,7 @@ jobs:
     assert "environment" in finding.message
 
     steps = workflow["jobs"]["build"]["steps"]
-    step_line = steps[0]["__line__"]
+    step_line = get_position(steps[0])[0]
     assert finding.line_number == step_line
     assert finding.column is not None
 
@@ -268,7 +268,7 @@ jobs:
     assert finding.rule_id == "check_reusable_inputs"
 
     steps = workflow["jobs"]["build"]["steps"]
-    assert finding.line_number == steps[0]["__line__"]
+    assert finding.line_number == get_position(steps[0])[0]
     assert finding.column is not None
 
 

--- a/ghast/tests/utils/test_yaml_handler.py
+++ b/ghast/tests/utils/test_yaml_handler.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from ghast.utils.yaml_handler import (
     load_yaml_with_positions,
     load_yaml_file_with_positions,
+    get_position,
     clean_positions,
     dump_yaml,
     find_yaml_files,
@@ -42,12 +43,10 @@ jobs:
     assert "jobs" in result
     assert "build" in result["jobs"]
 
-    assert "__line__" in result
-    assert "__column__" in result
-    assert "__line__" in result["jobs"]
-    assert "__column__" in result["jobs"]
-    assert "__line__" in result["jobs"]["build"]
-    assert "__column__" in result["jobs"]["build"]
+    assert get_position(result)[0] is not None
+    assert get_position(result)[1] is not None
+    assert get_position(result["jobs"])[0] is not None
+    assert get_position(result["jobs"]["build"])[0] is not None
 
 
 def test_load_yaml_file_with_positions(temp_dir):
@@ -72,10 +71,8 @@ jobs:
     assert "jobs" in result
     assert "build" in result["jobs"]
 
-    assert "__line__" in result
-    assert "__column__" in result
-    assert "__line__" in result["jobs"]
-    assert "__column__" in result["jobs"]
+    assert get_position(result)[0] is not None
+    assert get_position(result["jobs"])[0] is not None
 
 
 def test_clean_positions():
@@ -103,6 +100,26 @@ def test_clean_positions():
     assert cleaned["list"][0]["item"] == "value"
 
 
+def test_literal_line_keys_are_preserved():
+    """Literal __line__/__column__ YAML keys must not be stripped or overwritten."""
+    workflow = load_yaml_with_positions(
+        """
+name: preserve
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    __line__: literal-value
+    __column__: another-literal
+"""
+    )
+
+    job = workflow["jobs"]["build"]
+    assert job["__line__"] == "literal-value"
+    assert job["__column__"] == "another-literal"
+    assert get_position(job)[0] is not None
+
+
 def test_dump_yaml():
     """Test dumping YAML with formatting preservation."""
 
@@ -126,8 +143,8 @@ def test_dump_yaml():
     assert parsed["on"] == "push"
     assert "jobs" in parsed
 
-    assert "__line__" not in parsed
-    assert "__column__" not in parsed
+    assert parsed["__line__"] == 1
+    assert parsed["__column__"] == 0
 
     with tempfile.NamedTemporaryFile(mode="w+", delete=False) as f:
         dump_yaml(obj, f)
@@ -140,7 +157,7 @@ def test_dump_yaml():
 
     parsed = yaml.safe_load(content)
     assert parsed["name"] == "Test Workflow"
-    assert "__line__" not in parsed
+    assert parsed["__line__"] == 1
 
 
 def test_find_yaml_files(temp_dir):

--- a/ghast/utils/__init__.py
+++ b/ghast/utils/__init__.py
@@ -14,6 +14,7 @@ from .yaml_handler import (
     is_github_actions_workflow,
     extract_line_from_file,
     get_element_at_path,
+    get_position,
 )
 
 from .file_handler import (
@@ -81,6 +82,7 @@ __all__ = [
     "is_github_actions_workflow",
     "extract_line_from_file",
     "get_element_at_path",
+    "get_position",
     "is_git_repository",
     "find_repository_root",
     "has_github_workflows",

--- a/ghast/utils/yaml_handler.py
+++ b/ghast/utils/yaml_handler.py
@@ -8,29 +8,57 @@ including position-aware parsing and formatting preservation.
 import yaml
 from typing import Any, Dict, List, Optional, TextIO, Sequence, Union, cast
 from pathlib import Path
-from yaml.nodes import MappingNode, Node
+from yaml.nodes import Node
 
 
 class LineColumnLoader(yaml.SafeLoader):
-    """Custom YAML loader that tracks line and column information"""
+    """Custom YAML loader used for string-preserving resolution tweaks."""
 
-    def __init__(self, stream: TextIO | str) -> None:
-        super().__init__(stream)
 
-    def compose_node(self, parent: Any, index: Any) -> Node:
-        """Add line/column information to nodes"""
-        node = cast(Node, super().compose_node(parent, index))
-        setattr(node, "__line__", self.line + 1)
-        setattr(node, "__column__", self.column)
-        return node
+Position = tuple[Optional[int], Optional[int]]
+_positions_by_root_id: Dict[int, Dict[int, Position]] = {}
+_paths_by_root_id: Dict[int, Dict[tuple[Union[str, int], ...], Position]] = {}
 
-    def construct_mapping(self, node: MappingNode, deep: bool = False) -> Dict[Any, Any]:
-        """Add line/column information to dictionaries"""
-        mapping = cast(Dict[Any, Any], super().construct_mapping(node, deep=deep))
-        mapping["__line__"] = getattr(node, "__line__", None)
-        mapping["__column__"] = getattr(node, "__column__", None)
-        return mapping
 
+def _build_position_indexes(node: Node, obj: Any) -> tuple[Dict[int, Position], Dict[tuple[Union[str, int], ...], Position]]:
+    by_id: Dict[int, Position] = {}
+    by_path: Dict[tuple[Union[str, int], ...], Position] = {}
+
+    def walk(current_node: Node, current_obj: Any, path: tuple[Union[str, int], ...]) -> None:
+        position = (current_node.start_mark.line + 1, current_node.start_mark.column)
+        if isinstance(current_obj, (dict, list)):
+            by_id[id(current_obj)] = position
+        by_path[path] = position
+
+        if isinstance(current_node, yaml.nodes.MappingNode) and isinstance(current_obj, dict):
+            for key_node, value_node in current_node.value:
+                if not isinstance(key_node, yaml.nodes.ScalarNode):
+                    continue
+                key = key_node.value
+                if key in current_obj:
+                    walk(value_node, current_obj[key], (*path, key))
+        elif isinstance(current_node, yaml.nodes.SequenceNode) and isinstance(current_obj, list):
+            for idx, item_node in enumerate(current_node.value):
+                if idx < len(current_obj):
+                    walk(item_node, current_obj[idx], (*path, idx))
+
+    walk(node, obj, ())
+    return by_id, by_path
+
+
+def get_position(node_or_path: Any, root: Optional[Any] = None) -> Position:
+    """Get (line, column) metadata for a parsed YAML object or path."""
+    if root is not None:
+        root_id = id(root)
+        if isinstance(node_or_path, (tuple, list)):
+            return _paths_by_root_id.get(root_id, {}).get(tuple(node_or_path), (None, None))
+        return _positions_by_root_id.get(root_id, {}).get(id(node_or_path), (None, None))
+
+    for positions in _positions_by_root_id.values():
+        found = positions.get(id(node_or_path))
+        if found is not None:
+            return found
+    return (None, None)
 
 # PyYAML follows the YAML 1.1 specification which treats certain plain
 # strings such as ``on``, ``off``, ``yes`` and ``no`` as booleans.  In the
@@ -72,7 +100,12 @@ def load_yaml_with_positions(content: str) -> Dict[str, Any]:
     Raises:
         yaml.YAMLError: If YAML parsing fails
     """
-    return cast(Dict[str, Any], yaml.load(content, Loader=LineColumnLoader))
+    loaded = cast(Dict[str, Any], yaml.load(content, Loader=LineColumnLoader))
+    node_tree = cast(Node, yaml.compose(content, Loader=LineColumnLoader))
+    by_id, by_path = _build_position_indexes(node_tree, loaded)
+    _positions_by_root_id[id(loaded)] = by_id
+    _paths_by_root_id[id(loaded)] = by_path
+    return loaded
 
 
 def load_yaml_file_with_positions(file_path: str) -> Dict[str, Any]:
@@ -126,14 +159,12 @@ def dump_yaml(obj: Any, stream: Optional[TextIO] = None, **kwargs: Any) -> Optio
         YAML string if stream is None, otherwise None
     """
 
-    cleaned_obj = clean_positions(obj)
-
     kwargs.setdefault("sort_keys", False)
     kwargs.setdefault("default_flow_style", False)
 
     return cast(
         Optional[str],
-        yaml.dump(cleaned_obj, stream, Dumper=FormattingPreservingDumper, **kwargs),
+        yaml.dump(obj, stream, Dumper=FormattingPreservingDumper, **kwargs),
     )
 
 


### PR DESCRIPTION
### Motivation

- Provide a single, robust API for retrieving line/column metadata instead of embedding `__line__`/`__column__` keys throughout parsed YAML objects.
- Ensure position lookups work for any node (dict/list/scalar) and support path-based resolution to make scanner rules more reliable.

### Description

- Introduce `get_position` and internal position indexes in `ghast/utils/yaml_handler.py`, and populate indexes during `load_yaml_with_positions` by composing the YAML node tree.
- Replace direct `__line__`/`__column__` lookups in `ghast/core/scanner.py` with calls to `get_position`, and simplify traversal logic by removing ad-hoc key filtering for literal position keys.
- Export `get_position` from `ghast.utils` via `__init__.py` so tests and other modules can access it.
- Adjust `dump_yaml`/`clean_positions` behavior and update unit tests to reflect the new position API and to assert literal `__line__`/`__column__` keys are preserved when present.
- Add a new test `test_literal_line_keys_are_preserved` to ensure YAML keys named `__line__`/`__column__` are not stripped or overwritten by the position tracking system.

### Testing

- Ran the YAML handler unit tests in `ghast/tests/utils/test_yaml_handler.py`, which include the new `test_literal_line_keys_are_preserved`, and they passed. 
- Ran the scanner unit tests in `ghast/tests/core/test_scanner.py` after updating them to use `get_position`, and they passed. 
- Ran the full test suite with `pytest -q`, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6734da70883289fcadacaa941c78c)