### PR TITLE
Avoid import-time CLI execution by tightening ghast __init__ entrypoint guard

### DIFF
--- a/ghast/__init__.py
+++ b/ghast/__init__.py
@@ -51,14 +51,12 @@ __all__ = [
 ]
 
 
-if "main" not in globals():
+def main() -> None:
+    """Main entry point for the ghast CLI tool."""
+    from .cli import cli
 
-    def main() -> None:
-        """Main entry point for the ghast CLI tool"""
-        from .cli import cli
-
-        cli()
+    cli()
 
 
-if __name__ == "__main__" or "unittest.mock" in type(main).__module__:
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Motivation
- Prevent importing `ghast` from triggering CLI execution and ensure `main()` only runs when the package is executed as a script under `if __name__ == "__main__":`.

### Description
- Removed the conditional that invoked `main()` based on `"unittest.mock" in type(main).__module__`, made `main()` a normal module-level function available for entrypoints (e.g. `ghast = "ghast:main"`), and left only the `if __name__ == "__main__": main()` guard.

### Testing
- Ran `python -c "import ghast; print(callable(ghast.main))"` which printed `True`, confirming that importing `ghast` does not execute the CLI and `main` is exposed as a callable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f675dfe6148328b80d571e4f9edcdf)