### PR TITLE
Use normalized severity threshold consistently in WorkflowScanner.scan_file

### DIFF
--- a/ghast/core/scanner.py
+++ b/ghast/core/scanner.py
@@ -135,7 +135,7 @@ class WorkflowScanner:
             engine_findings = self.rule_engine.scan_workflow(
                 content,
                 file_path,
-                severity_threshold=severity_threshold,
+                severity_threshold=normalized_threshold,
             )
             normalized_findings = self._normalize_rule_ids(engine_findings)
             findings.extend(
@@ -143,7 +143,7 @@ class WorkflowScanner:
                     finding
                     for finding in normalized_findings
                     if SEVERITY_LEVELS.index(finding.severity)
-                    >= SEVERITY_LEVELS.index(severity_threshold)
+                    >= SEVERITY_LEVELS.index(normalized_threshold)
                 ]
             )
 


### PR DESCRIPTION
### Motivation
- Ensure severity normalization is centralized and avoid using unvalidated raw `severity_threshold` strings when scanning and filtering findings.

### Description
- Pass `normalized_threshold` into `self.rule_engine.scan_workflow(...)` and compare findings against `SEVERITY_LEVELS.index(normalized_threshold)` in the list-comprehension filter.

### Testing
- Ran `pytest -q` which failed during collection due to `ModuleNotFoundError: No module named 'ghast'`, and ran `PYTHONPATH=. pytest -q ghast/tests/core/test_scanner.py -q` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f675de78548328afcfb9b8173b9dc7)