### PR TITLE
Forward CLI `--disable` into `_prepare_scan` and normalize rule keys

### DIFF
--- a/ghast/cli.py
+++ b/ghast/cli.py
@@ -75,7 +75,8 @@ def _prepare_scan(
         if config_data is None:
             config_data = {}
         for rule in disable:
-            config_data[rule] = False
+            rule_key = rule if rule.startswith("check_") else f"check_{rule}"
+            config_data[rule_key] = False
 
     path = Path(repo_path)
     if path.is_file() and path.suffix in [".yml", ".yaml"]:
@@ -183,6 +184,7 @@ def scan(
         strict,
         config,
         severity_threshold,
+        disable=disable,
         show_file_count=output == "text",
         echo=output == "text",
     )


### PR DESCRIPTION
### Motivation

- Ensure CLI `--disable` options are respected by the scan path so users can disable rules at runtime. 
- Make disabled rule IDs match the config shape the rule engine expects (`check_*`) so disable semantics are applied consistently.

### Description

- Update `scan()` to forward the CLI `disable` tuple into `_prepare_scan()` via `disable=disable` so the flag is honored during scans. 
- Update `_prepare_scan()` to normalize each disabled rule to the `check_<rule>` top-level config key when the provided ID does not already start with `check_`, and then set that key to `False` in the config used for scanning. 

### Testing

- Running `pytest -q ghast/tests/test_cli.py -k "disable or scan"` without adjusting `PYTHONPATH` failed during collection with `ModuleNotFoundError` (import path environment issue). 
- Running `PYTHONPATH=. pytest -q ghast/tests/test_cli.py -k "disable or scan"` succeeded with `8 passed, 15 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f675dd353c8328b92c7f1c8617aab0)