### PR TITLE
Add pytest pythonpath to pyproject to fix test imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ exclude = ["ghast/tests"]
 
 [tool.pytest.ini_options]
 testpaths = ["ghast/tests"]
+pythonpath = ["."]
 python_files = "test_*.py"
 python_functions = "test_*"
 python_classes = "Test*"


### PR DESCRIPTION
### Motivation
- Ensure pytest can import the local `ghast` package during test collection in clean environments to avoid build-blocking `ModuleNotFoundError`.

### Description
- Add `pythonpath = ["."]` under `[tool.pytest.ini_options]` in `pyproject.toml` so pytest includes the repository root on `sys.path` during collection.

### Testing
- Ran `python -m pip install -q -r requirements-dev.txt && pytest -q` and `pytest -q`; import/collection errors are resolved and the test run proceeds, with `167` tests passing and `3` behavioral tests failing (`test_fix_workflow_file`, `test_scan_file`, `test_module_execution`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f676c4b7f88328a358025cb0495d20)