### PR TITLE
Normalize Finding.severity for mypy and fix JSON summary typing

### DIFF
--- a/ghast/cli.py
+++ b/ghast/cli.py
@@ -69,7 +69,7 @@ def _prepare_scan(
             raise click.ClickException(f"Error loading config file: {e}")
 
     else:
-        config_data = copy.deepcopy(config_default) if config_default is not None else None
+        config_data = copy.deepcopy(config_default) if config_default is not None else {}
 
     if disable:
         if config_data is None:
@@ -97,7 +97,8 @@ def _prepare_scan(
 
         for finding in findings:
             severity_counts = cast(Dict[str, int], stats["severity_counts"])
-            severity_counts[finding.severity] = severity_counts.get(finding.severity, 0) + 1
+            finding_severity = normalize_severity(finding.severity)
+            severity_counts[finding_severity] = severity_counts.get(finding_severity, 0) + 1
             rule_counts = cast(Dict[str, int], stats["rule_counts"])
             rule_counts[finding.rule_id] = rule_counts.get(finding.rule_id, 0) + 1
     else:
@@ -284,7 +285,8 @@ def fix(
 
         for finding in findings:
             severity_counts = cast(Dict[str, int], stats["severity_counts"])
-            severity_counts[finding.severity] = severity_counts.get(finding.severity, 0) + 1
+            finding_severity = normalize_severity(finding.severity)
+            severity_counts[finding_severity] = severity_counts.get(finding_severity, 0) + 1
             rule_counts = cast(Dict[str, int], stats["rule_counts"])
             rule_counts[finding.rule_id] = rule_counts.get(finding.rule_id, 0) + 1
             if finding.can_fix:
@@ -454,9 +456,10 @@ def analyze(file_path: str) -> None:
 
         by_severity: Dict[str, List[Finding]] = {}
         for finding in findings:
-            if finding.severity not in by_severity:
-                by_severity[finding.severity] = []
-            by_severity[finding.severity].append(finding)
+            finding_severity = normalize_severity(finding.severity)
+            if finding_severity not in by_severity:
+                by_severity[finding_severity] = []
+            by_severity[finding_severity].append(finding)
 
         for severity in ["CRITICAL", "HIGH", "MEDIUM", "LOW"]:
             if severity in by_severity:

--- a/ghast/core/scanner.py
+++ b/ghast/core/scanner.py
@@ -142,7 +142,7 @@ class WorkflowScanner:
                 [
                     finding
                     for finding in normalized_findings
-                    if SEVERITY_LEVELS.index(finding.severity)
+                    if SEVERITY_LEVELS.index(normalize_severity(finding.severity))
                     >= SEVERITY_LEVELS.index(normalized_threshold)
                 ]
             )

--- a/ghast/reports/console.py
+++ b/ghast/reports/console.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, TextIO
 import click
 
 from ..core import SEVERITY_LEVELS, Finding
+from ..core.scanner import normalize_severity
 from ..utils.formatter import SEVERITY_COLORS  # noqa: F401
 
 # Mapping of severity levels to Click color names used for console output
@@ -96,7 +97,7 @@ def format_finding(finding: Finding, verbose: bool = False, show_remediation: bo
     Returns:
         Formatted finding as string
     """
-    severity = finding.severity
+    severity = normalize_severity(finding.severity)
     symbol = get_severity_symbol(severity)
 
     formatted = (

--- a/ghast/reports/json.py
+++ b/ghast/reports/json.py
@@ -23,7 +23,7 @@ def finding_to_dict(finding: Finding) -> Dict[str, Any]:
     Returns:
         Dictionary representation of the finding
     """
-    result = {
+    result: Dict[str, Any] = {
         "rule_id": finding.rule_id,
         "severity": finding.severity,
         "message": finding.message,
@@ -88,17 +88,19 @@ def generate_json_summary(stats: Dict[str, Any]) -> str:
         JSON string representation of the summary
     """
 
+    summary_data: Dict[str, Any] = {
+        "total_files": stats.get("total_files", 0),
+        "total_findings": stats.get("total_findings", 0),
+        "severity_counts": stats.get("severity_counts", {}),
+        "rule_counts": stats.get("rule_counts", {}),
+        "fixable_findings": stats.get("fixable_findings", 0),
+        "scan_duration_seconds": None,
+    }
+
     summary: Dict[str, Any] = {
         "ghast_version": __version__,
         "generated_at": datetime.now().isoformat(),
-        "summary": {
-            "total_files": stats.get("total_files", 0),
-            "total_findings": stats.get("total_findings", 0),
-            "severity_counts": stats.get("severity_counts", {}),
-            "rule_counts": stats.get("rule_counts", {}),
-            "fixable_findings": stats.get("fixable_findings", 0),
-            "scan_duration_seconds": None,
-        },
+        "summary": summary_data,
     }
 
     start_time = stats.get("start_time")

--- a/ghast/reports/sarif.py
+++ b/ghast/reports/sarif.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, cast
 
 from ..core import Finding
+from ..core.scanner import normalize_severity
 from ..utils.version import __version__
 
 SARIF_VERSION = "2.1.0"
@@ -104,7 +105,7 @@ def finding_to_sarif_result(finding: Finding, repo_root: Optional[str] = None) -
 
     result: Dict[str, Any] = {
         "ruleId": finding.rule_id,
-        "level": severity_to_sarif_level(finding.severity),
+        "level": severity_to_sarif_level(normalize_severity(finding.severity)),
         "message": {"text": finding.message},
         "locations": [{"physicalLocation": {"artifactLocation": {"uri": file_path}}}],
     }
@@ -193,7 +194,7 @@ def generate_sarif_report(
         if finding.rule_id not in rules_dict:
             rule = rule_to_sarif_rule(
                 finding.rule_id,
-                finding.severity,
+                normalize_severity(finding.severity),
                 description=finding.message,
                 help_text=finding.remediation,
             )


### PR DESCRIPTION
### Motivation

- mypy reported multiple errors where `Finding.severity` had type `str | Severity` and was used in list/dict indexing or passed to functions expecting `str`, causing `arg-type`/`index` errors.
- JSON report generation relied on inferred untyped dicts which caused incompatible assignment warnings under stricter typing.

### Description

- Normalize `Finding.severity` with `normalize_severity(...)` before any indexing or calls that expect a `str` in the scanner, CLI, console, and SARIF reporting paths (updates in `ghast/core/scanner.py`, `ghast/cli.py`, `ghast/reports/console.py`, and `ghast/reports/sarif.py`).
- Added necessary imports for `normalize_severity` where used and ensured SARIF uses normalized severity for level mapping and rule metadata.
- Made JSON report typing explicit by annotating per-finding dicts as `Dict[str, Any]` and extracting a typed `summary_data` before embedding it in the final payload (`ghast/reports/json.py`).
- Ensure `_prepare_scan` defaults `config_data` to an empty dict when no config is provided so subsequent mutation/indexing is well-typed (`ghast/cli.py`).

### Testing

- Ran `mypy ghast --disable-error-code import-untyped` which completed successfully and no longer reports the prior `str | Severity` `arg-type`/`index` errors.
- Running plain `mypy ghast` still surfaces `import-untyped` warnings for missing third-party stubs (PyYAML), which are unrelated to these changes and remain as environment notes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f67cf912e483288f0efa81322732d5)