### PR TITLE
Use timezone-aware UTC timestamp for file backups

### DIFF
--- a/ghast/utils/file_handler.py
+++ b/ghast/utils/file_handler.py
@@ -108,7 +108,7 @@ def create_timestamped_backup(file_path: str, suffix: str = ".bak") -> str:
     Raises:
         FileNotFoundError: If the source file doesn't exist
     """
-    timestamp = datetime.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d_%H%M%S")
     stem = os.path.splitext(file_path)[0]  # drop .ext
     backup_path = f"{stem}.{timestamp}{suffix}"
     shutil.copy2(file_path, backup_path)


### PR DESCRIPTION
### Motivation
- Replace deprecated `datetime.datetime.utcnow()` with an explicit timezone-aware UTC timestamp to avoid deprecation warnings and ensure backups have timezone-aware timestamps.

### Description
- Update `create_timestamped_backup` in `ghast/utils/file_handler.py` to use `datetime.datetime.now(datetime.timezone.utc)` for timestamp generation.

### Testing
- Ran `pytest -q` and the test suite passed (`170 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f683c84acc83289a5b51580054cc43)