### PR TITLE
ci: switch checkout steps to actions/checkout@v4

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:    
     - name: Checkout repository
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
     
@@ -59,7 +59,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         persist-credentials: false
@@ -112,7 +112,7 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
 
@@ -146,7 +146,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
 


### PR DESCRIPTION
### Motivation
- Address Ghast token-security findings and standardize `actions/checkout` references while keeping explicit credential hardening.

### Description
- Updated all `actions/checkout` usages to `actions/checkout@v4` in `.github/workflows/python-app.yml` and preserved `persist-credentials: false` on each checkout step.

### Testing
- Verified the workflow changes with `git diff -- .github/workflows/python-app.yml` and confirmed the `uses` entries were updated.
- Attempted `ghast scan . --severity-threshold MEDIUM` but it could not be run in this environment because `ghast` is not installed (`ghast: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f68be3b05c8328a97a7e2e7e11f2a0)