### PR TITLE
ci: pin actions/checkout to specific commit SHA

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:    
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
       with:
         persist-credentials: false
     
@@ -59,7 +59,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
       with:
         fetch-depth: 0
         persist-credentials: false
@@ -112,7 +112,7 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
       with:
         persist-credentials: false
 
@@ -146,7 +146,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
       with:
         persist-credentials: false
 


### PR DESCRIPTION
### Motivation
- Address security findings from the workflow scanner that flagged unpinned actions and checkout credential persistence risks.
- Ensure reproducible and auditable runner behavior by pinning `actions/checkout` to an immutable commit SHA.

### Description
- Updated `.github/workflows/python-app.yml` to replace `uses: actions/checkout@v4` with `uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1` in all checkout steps.
- Applied the pin to the `test`, `lint`, `self-check`, and `build-and-publish` jobs.
- Preserved the existing secure checkout setting `persist-credentials: false` on each checkout step.

### Testing
- Attempted to run `ghast scan . --severity-threshold MEDIUM`, but the command failed in this environment with `command not found` so the scanner could not be re-run here (failed).
- No other automated tests were executed in this environment after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f68cba98ec8328a9273d81b93d5dfe)