### PR TITLE
Fix crash when sorting reusable input references with missing positions

### DIFF
--- a/ghast/core/scanner.py
+++ b/ghast/core/scanner.py
@@ -674,7 +674,18 @@ class WorkflowScanner:
         if not references:
             return findings
 
-        for input_name, line, column in sorted(references):
+        sorted_references = sorted(
+            references,
+            key=lambda ref: (
+                ref[0],
+                ref[1] is None,
+                ref[1] if ref[1] is not None else -1,
+                ref[2] is None,
+                ref[2] if ref[2] is not None else -1,
+            ),
+        )
+
+        for input_name, line, column in sorted_references:
             if inputs_section is None:
                 message = f"Reusable workflow references input '{input_name}' but 'on.workflow_call.inputs' is not defined"
             elif input_name not in defined_inputs:

--- a/ghast/tests/core/test_scanner.py
+++ b/ghast/tests/core/test_scanner.py
@@ -307,6 +307,41 @@ jobs:
     assert finding.column is not None
 
 
+def test_check_reusable_inputs_handles_mixed_position_types(monkeypatch):
+    """Sorting input references should not fail when some positions are missing."""
+
+    workflow = {
+        "on": {"workflow_call": {"inputs": {"existing": {"required": True}}}},
+        "jobs": {
+            "build": {
+                "steps": [
+                    {"run": 'echo "${{ inputs.missing }}"'},
+                    {"run": 'echo "${{ inputs.missing }}"'},
+                ]
+            }
+        },
+    }
+
+    first_step = workflow["jobs"]["build"]["steps"][0]
+    second_step = workflow["jobs"]["build"]["steps"][1]
+
+    def fake_get_position(node):
+        if node is first_step:
+            return (12, 3)
+        if node is second_step:
+            return (None, None)
+        return (None, None)
+
+    monkeypatch.setattr("ghast.core.scanner.get_position", fake_get_position)
+
+    scanner = WorkflowScanner()
+    findings = scanner.check_reusable_inputs(workflow, "reusable.yml")
+
+    assert len(findings) == 2
+    assert all(f.rule_id == "check_reusable_inputs" for f in findings)
+    assert all("missing" in f.message for f in findings)
+
+
 def test_check_ppe_vulnerabilities(insecure_workflow_file):
     """Test check_ppe_vulnerabilities rule."""
     scanner = WorkflowScanner()


### PR DESCRIPTION
### Motivation
- `check_reusable_inputs` collected `(input_name, line, column)` tuples and called `sorted()` directly, which raises `TypeError` in Python 3 when `line`/`column` values mix `int` and `NoneType` during comparisons. 
- The change ensures sorting is deterministic and safe even when position metadata is missing. 
- This prevents runtime crashes when scanning reusable workflows that reference inputs without full position information.

### Description
- Replace direct `sorted(references)` with `sorted(..., key=...)` in `ghast/core/scanner.py` using a key that orders by input name and treats `None` line/column values deterministically by using boolean flags and `-1` fallbacks. 
- Preserve original behavior of reporting findings while preventing comparison between `None` and `int`. 
- Add a regression test in `ghast/tests/core/test_scanner.py` that monkeypatches `get_position` to return mixed `(int, int)` and `(None, None)` values and asserts that `check_reusable_inputs` returns findings instead of crashing.

### Testing
- Ran the reusable-input-focused tests with `pytest -q ghast/tests/core/test_scanner.py -k reusable_inputs` and observed all relevant tests passed with output `4 passed, 17 deselected`. 
- The newly added regression test `test_check_reusable_inputs_handles_mixed_position_types` passed under the same run. 
- No test failures were introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6912fbaf4832881b6b59b03c46c2f)