### PR TITLE
Avoid mutating Finding instances when normalizing rule IDs

### DIFF
--- a/ghast/core/scanner.py
+++ b/ghast/core/scanner.py
@@ -6,7 +6,7 @@ discovering security issues and providing findings.
 """
 
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from pathlib import Path
 from enum import Enum
@@ -164,18 +164,16 @@ class WorkflowScanner:
         """Normalize engine rule IDs to scanner-compatible check_* naming."""
         normalized: List[Finding] = []
         for finding in findings:
+            normalized_rule_id = finding.rule_id
+
             if finding.rule_id.startswith("rule_error."):
                 _, _, raw_rule = finding.rule_id.partition(".")
-                if raw_rule.startswith("check_"):
-                    normalized.append(finding)
-                else:
-                    finding.rule_id = f"rule_error.check_{raw_rule}"
-                    normalized.append(finding)
-            elif finding.rule_id.startswith("check_"):
-                normalized.append(finding)
-            else:
-                finding.rule_id = f"check_{finding.rule_id}"
-                normalized.append(finding)
+                if not raw_rule.startswith("check_"):
+                    normalized_rule_id = f"rule_error.check_{raw_rule}"
+            elif not finding.rule_id.startswith("check_"):
+                normalized_rule_id = f"check_{finding.rule_id}"
+
+            normalized.append(replace(finding, rule_id=normalized_rule_id))
         return normalized
 
     def scan_directory(


### PR DESCRIPTION
### Motivation
- `_normalize_rule_ids` previously modified `Finding.rule_id` in-place, which caused shared-state side effects when the same `Finding` objects were referenced elsewhere (e.g., engine vs scanner), breaking assertions that compare them.
- The intent is to preserve original `Finding` objects and return scanner-friendly normalized copies to avoid surprising mutations.

### Description
- Add `replace` to the `dataclasses` import and compute a local `normalized_rule_id` instead of mutating `finding.rule_id` directly.
- Keep existing normalization rules for `rule_error.*` and non-`check_` IDs while constructing the normalized ID into the local variable.
- Return fresh `Finding` instances via `dataclasses.replace(finding, rule_id=normalized_rule_id)` so no input objects are mutated.

### Testing
- Ran `pytest -q ghast/tests/core/test_scanner.py::test_scan_file_matches_rule_engine_findings` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6914411a08328b7fd8f10cae21a04)