### PR TITLE
Preserve parent step line positions in `check_tokens` walker

### DIFF
--- a/ghast/core/scanner.py
+++ b/ghast/core/scanner.py
@@ -551,24 +551,24 @@ class WorkflowScanner:
                 current_line, current_column = get_position(node)
                 current_line = current_line if current_line is not None else line
                 current_column = current_column if current_column is not None else column
-                for key, value in node.items():
-                    value_line, value_column = get_position(value)
-                    walk(
-                        value,
-                        value_line if value_line is not None else current_line,
-                        value_column if value_column is not None else current_column,
-                    )
+                for _, value in node.items():
+                    next_line, next_column = current_line, current_column
+                    if isinstance(value, (dict, list)):
+                        value_line, value_column = get_position(value)
+                        next_line = value_line if value_line is not None else current_line
+                        next_column = value_column if value_column is not None else current_column
+                    walk(value, next_line, next_column)
             elif isinstance(node, list):
                 current_line, current_column = get_position(node)
                 current_line = current_line if current_line is not None else line
                 current_column = current_column if current_column is not None else column
                 for item in node:
-                    item_line, item_column = get_position(item)
-                    walk(
-                        item,
-                        item_line if item_line is not None else current_line,
-                        item_column if item_column is not None else current_column,
-                    )
+                    next_line, next_column = current_line, current_column
+                    if isinstance(item, (dict, list)):
+                        item_line, item_column = get_position(item)
+                        next_line = item_line if item_line is not None else current_line
+                        next_column = item_column if item_column is not None else current_column
+                    walk(item, next_line, next_column)
             else:
                 if not isinstance(node, str):
                     return
@@ -642,24 +642,24 @@ class WorkflowScanner:
                 current_line, current_column = get_position(node)
                 current_line = current_line if current_line is not None else line
                 current_column = current_column if current_column is not None else column
-                for key, value in node.items():
-                    value_line, value_column = get_position(value)
-                    walk(
-                        value,
-                        value_line if value_line is not None else current_line,
-                        value_column if value_column is not None else current_column,
-                    )
+                for _, value in node.items():
+                    next_line, next_column = current_line, current_column
+                    if isinstance(value, (dict, list)):
+                        value_line, value_column = get_position(value)
+                        next_line = value_line if value_line is not None else current_line
+                        next_column = value_column if value_column is not None else current_column
+                    walk(value, next_line, next_column)
             elif isinstance(node, list):
                 current_line, current_column = get_position(node)
                 current_line = current_line if current_line is not None else line
                 current_column = current_column if current_column is not None else column
                 for item in node:
-                    item_line, item_column = get_position(item)
-                    walk(
-                        item,
-                        item_line if item_line is not None else current_line,
-                        item_column if item_column is not None else current_column,
-                    )
+                    next_line, next_column = current_line, current_column
+                    if isinstance(item, (dict, list)):
+                        item_line, item_column = get_position(item)
+                        next_line = item_line if item_line is not None else current_line
+                        next_column = item_column if item_column is not None else current_column
+                    walk(item, next_line, next_column)
             elif isinstance(node, str):
                 if "${{" not in node or "inputs." not in node:
                     return


### PR DESCRIPTION
### Motivation
- Findings produced by `check_tokens` were being attributed to nested scalar YAML nodes instead of their parent step, causing line numbers to drift away from the intended step line.
- Tests like `test_check_tokens` assert that a finding's `line_number` matches the parent step, so the walker must propagate parent positions to string leaves.

### Description
- Updated the recursive `walk` in `WorkflowScanner.check_tokens` to propagate the current parent `line`/`column` down to leaf strings instead of always calling `get_position` on every node. 
- Only call `get_position` for container nodes (`dict`/`list`) and use `next_line`/`next_column` for subsequent recursion so scalars inherit their parent location. 
- Applied the same position-propagation pattern to the similar walker used in `check_reusable_inputs` to keep input reference locations aligned with their parent job/step. 

### Testing
- Ran `pytest -q ghast/tests/core/test_scanner.py::test_check_tokens` which passed. 
- Ran `pytest -q ghast/tests/core/test_scanner.py` which passed (all tests in that file succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6914e2b588328a4e1c50f8a8a1c2e)