### PR TITLE
Fix: Initialize severity_counts for single-file `fix` command

### DIFF
--- a/ghast/cli.py
+++ b/ghast/cli.py
@@ -275,10 +275,12 @@ def fix(
         scanner = WorkflowScanner(strict=strict, config=config_data)
         findings = scanner.scan_file(str(path), severity_threshold)
 
+        from .core import SEVERITY_LEVELS
+
         stats: Dict[str, Any] = {
             "total_files": 1,
             "total_findings": len(findings),
-            "severity_counts": {},
+            "severity_counts": {level: 0 for level in SEVERITY_LEVELS},
             "rule_counts": {},
             "fixable_findings": 0,
         }


### PR DESCRIPTION
### Motivation
- The `fix` command's single-file path initialized `stats["severity_counts"]` as an empty dict which could lead to missing severity keys or `KeyError`s and was inconsistent with the `scan` behavior.

### Description
- In `ghast/cli.py` import `SEVERITY_LEVELS` and initialize `stats["severity_counts"]` for single-file `fix` runs as `{level: 0 for level in SEVERITY_LEVELS}` instead of `{}` to ensure all severity keys exist.

### Testing
- Ran targeted CLI tests with `pytest -q ghast/tests/test_cli.py -k 'fix and single or dry_run'` and the suite completed with `2 passed, 21 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6915640208328a609dd0c4ea90d22)