### PR TITLE
Fix EnvironmentInjectionRule syntax and checkout detection

### DIFF
--- a/ghast/rules/security.py
+++ b/ghast/rules/security.py
@@ -326,8 +326,8 @@ class EnvironmentInjectionRule(StepRule):
                 if "uses" in step and step["uses"].startswith("actions/checkout"):
                     if (
                         "with" not in step
-                        or "persist-credentials" not in step["with"]                        
-                        or step["with"]["persist-credentials"] != False
+                        or "persist-credentials" not in step["with"]
+                        or step["with"]["persist-credentials"] is not False
                     ):
                         findings.append(
                             self.create_finding(
@@ -335,6 +335,17 @@ class EnvironmentInjectionRule(StepRule):
                                     f"actions/checkout in job '{job_id}' step {step_idx+1} "
                                     "does not disable credential persistence"
                                 ),
+                                file_path=file_path,
+                                line_number=step.get("__line__"),
+                                column=step.get("__column__"),
+                                remediation=(
+                                    "Add 'persist-credentials: false' to the 'with' section of actions/checkout steps"
+                                ),
+                                can_fix=True,
+                            )
+                        )
+
+                    checkout_step_idx = step_idx
 
             if checkout_step_idx is not None:
                 for step_idx, step in enumerate(steps):


### PR DESCRIPTION
### Motivation
- Resolve a syntax error in the environment injection rule that prevented test collection and import of the package.
- Ensure `EnvironmentInjectionRule` correctly identifies `actions/checkout` steps and records the checkout index so subsequent modifications to `GITHUB_ENV`/`GITHUB_PATH` are evaluated.
- Keep finding metadata consistent with other security rules so fix suggestions and location data are available for detected issues.

### Description
- Fixed an unclosed `self.create_finding(...)` call in `EnvironmentInjectionRule.check` to eliminate the `SyntaxError` in `ghast/rules/security.py`.
- Restored finding metadata fields `file_path`, `line_number`, and `column`, added a `remediation` message, and set `can_fix=True` for the checkout credential finding.
- Ensured `checkout_step_idx` is assigned when an `actions/checkout` step is encountered so later steps after checkout are inspected.
- Normalized the `persist-credentials` check to use `is not False` for clearer boolean comparison.

### Testing
- Initial test collection failed due to the `SyntaxError` during import of `ghast.rules.security` which blocked pytest collection.
- Ran `pytest -q` after the fix and all tests passed: `171 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f693a65920832897b4a7ffcb82b74f)