### PR TITLE
Remove default line/column fallback in Rule.create_finding

### DIFF
--- a/ghast/rules/base.py
+++ b/ghast/rules/base.py
@@ -95,19 +95,13 @@ class Rule(ABC):
         Returns:
             Finding object
         """
-        normalized_line = line_number
-        normalized_column = column
-        if normalized_line is None and "Missing workflow name" not in message:
-            normalized_line = 1
-            normalized_column = 1 if normalized_column is None else normalized_column
-
         return Finding(
             rule_id=self.rule_id,
             severity=severity or self.severity,
             message=message,
             file_path=file_path,
-            line_number=normalized_line,
-            column=normalized_column,
+            line_number=line_number,
+            column=column,
             remediation=remediation or self.remediation,
             context=context or {},
             can_fix=can_fix if can_fix is not None else self.can_fix,


### PR DESCRIPTION
### Motivation
- `Rule.create_finding` previously rewrote missing locations to `line 1` / `column 1`, which masked upstream location-resolution bugs and made absent source positions implicit rather than visible.

### Description
- Removed the normalization fallback in `ghast/rules/base.py` so `line_number` and `column` are passed through directly to `Finding(...)` and `None` now propagates for missing positions.

### Testing
- Ran `python -m compileall ghast/rules/base.py` which completed successfully; no unit test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e56675a883289addba9ebb23d225)