### PR TITLE
Normalize rule boolean comparisons for YAML string coercion

### DIFF
--- a/ghast/rules/base.py
+++ b/ghast/rules/base.py
@@ -12,6 +12,16 @@ from typing import Any, Dict, List, Optional
 from ..core import Finding
 
 
+def _is_false(value: Any) -> bool:
+    """Return True when value semantically represents false."""
+    return value is False or (isinstance(value, str) and value.lower() == "false")
+
+
+def _is_true(value: Any) -> bool:
+    """Return True when value semantically represents true."""
+    return value is True or (isinstance(value, str) and value.lower() == "true")
+
+
 class Rule(ABC):
     """Base class for all ghast security rules"""
 

--- a/ghast/rules/best_practices.py
+++ b/ghast/rules/best_practices.py
@@ -9,7 +9,7 @@ import re
 from typing import Any, Dict, List
 
 from ..core import Finding
-from .base import JobRule, Rule, StepRule, WorkflowRule
+from .base import JobRule, Rule, StepRule, WorkflowRule, _is_true
 
 
 class TimeoutRule(JobRule):
@@ -264,7 +264,7 @@ class ContinueOnErrorRule(Rule):
         for job_id, job in jobs.items():
             if job_id in ("__line__", "__column__") or not isinstance(job, dict):
                 continue
-            if job.get("continue-on-error") is True:
+            if _is_true(job.get("continue-on-error")):
                 findings.append(
                     self.create_finding(
                         message=f"Job '{job_id}' has 'continue-on-error: true'",
@@ -279,7 +279,7 @@ class ContinueOnErrorRule(Rule):
                 if not isinstance(step, dict):
                     continue
 
-                if step.get("continue-on-error") is True:
+                if _is_true(step.get("continue-on-error")):
                     findings.append(
                         self.create_finding(
                             message=f"Step {step_idx+1} in job '{job_id}' has 'continue-on-error: true'",

--- a/ghast/rules/security.py
+++ b/ghast/rules/security.py
@@ -8,7 +8,7 @@ import re
 from typing import Any, Dict, List
 
 from ..core import Finding
-from .base import Rule, StepRule, TokenRule, WorkflowRule
+from .base import Rule, StepRule, TokenRule, WorkflowRule, _is_false
 
 
 class PermissionsRule(WorkflowRule):
@@ -327,7 +327,7 @@ class EnvironmentInjectionRule(StepRule):
                     if (
                         "with" not in step
                         or "persist-credentials" not in step["with"]
-                        or step["with"]["persist-credentials"] is not False
+                        or not _is_false(step["with"]["persist-credentials"])
                     ):
                         findings.append(
                             self.create_finding(
@@ -418,7 +418,7 @@ class TokenSecurityRule(TokenRule):
                     if (
                         "with" not in step
                         or "persist-credentials" not in step["with"]
-                        or step["with"]["persist-credentials"] is not False
+                        or not _is_false(step["with"]["persist-credentials"])
                     ):
                         findings.append(
                             self.create_finding(


### PR DESCRIPTION
### Motivation
- YAML parsers can surface boolean-like values as strings (e.g. `"true"`/`"false"`), making strict identity checks brittle and causing false positives/negatives. 
- Rules that check booleans (`continue-on-error`, `with.persist-credentials`) must tolerate string-coerced YAML to remain robust across parsing quirks. 

### Description
- Added shared helpers ` _is_false` and `_is_true` in `ghast/rules/base.py` to semantically normalize boolean values and case-insensitive string representations. 
- Updated `ContinueOnErrorRule` in `ghast/rules/best_practices.py` to use ``_is_true(...)`` for both job- and step-level `continue-on-error` checks. 
- Updated `EnvironmentInjectionRule` and `TokenSecurityRule` in `ghast/rules/security.py` to use ``_is_false(...)`` when validating `with.persist-credentials` instead of `is not False`. 

### Testing
- Ran targeted unit tests: `pytest -q ghast/tests/rules/test_best_practices.py::test_continue_on_error_rule ghast/tests/rules/test_security_rules.py::test_environment_injection_rule ghast/tests/rules/test_security_rules.py::test_token_security_rule`. 
- Result: all targeted tests passed (3 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e56e53e48328bef359486615c5b9)