### PR TITLE
Remove import-time main shim and stabilize module execution test

### DIFF
--- a/ghast/__init__.py
+++ b/ghast/__init__.py
@@ -1,6 +1,3 @@
-_previous_main = globals().get("main")
-if callable(_previous_main) and _previous_main.__class__.__module__.startswith("unittest.mock"):
-    _previous_main()
 
 """
 ghast - GitHub Actions Security Tool

--- a/ghast/tests/test_main.py
+++ b/ghast/tests/test_main.py
@@ -2,8 +2,8 @@
 test_main.py - Tests for the main package functionality
 """
 
-import pytest
-from unittest.mock import patch
+from pathlib import Path
+from unittest.mock import Mock, patch
 
 import ghast
 
@@ -49,11 +49,16 @@ def test_main_function():
 
 
 def test_module_execution():
-    """Test direct module execution."""
-    with patch("ghast.main") as mock_main:
-        with patch("ghast.__name__", "__main__"):
+    """Test direct module execution guard without reloading the package."""
+    module_code = Path("ghast/__init__.py").read_text(encoding="utf-8")
 
-            import importlib
+    mock_main = Mock()
+    exec_globals = {"__name__": "ghast", "__package__": "ghast", "__file__": "ghast/__init__.py", "main": mock_main}
+    exec(module_code, exec_globals)
 
-            importlib.reload(ghast)
-            mock_main.assert_called_once()
+    mock_main.assert_not_called()
+
+    exec_globals_main = {"__name__": "__main__", "__package__": "ghast", "__file__": "ghast/__init__.py", "main": mock_main}
+    exec(module_code, exec_globals_main)
+
+    mock_main.assert_called_once()


### PR DESCRIPTION
### Motivation
- Prevent a mock `main` from being invoked at package import by removing an import-time shim that executed `main` when a mocked object was present. 
- Eliminate a fragile reliance on `importlib.reload` in tests which caused mock objects to run during normal imports. 
- Make the module-execution behavior testable without reloading the package to avoid side effects at import time. 

### Description
- Removed the import-time mock-execution shim at the top of `ghast/__init__.py` so package import no longer calls a mocked `main`. 
- Rewrote `ghast/tests/test_main.py::test_module_execution` to read `ghast/__init__.py` source and `exec` it with controlled globals rather than using `importlib.reload`. 
- Updated the test to provide `__name__`, `__package__`, and `__file__` in the execution globals and to use `Mock` from `unittest.mock` to verify that `main` is not called on import-style execution and is called once on direct execution. 

### Testing
- Ran `pytest -q ghast/tests/test_main.py` and the suite completed with all tests passing (`4 passed`). 
- The modified test verifies both import-style and direct execution behaviors without causing side effects during normal package import.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e575d3a88328a5b1274b118c003c)