### PR TITLE
ci: remove unsupported persist-credentials inputs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -69,7 +69,6 @@ jobs:
       with:
         python-version: '3.10'
         cache: 'pip'
-        persist-credentials: false
         
     - name: Install dependencies
       run: |
@@ -156,7 +155,6 @@ jobs:
       with:
         python-version: '3.10'
         cache: 'pip'
-        persist-credentials: false
 
     - name: Install build dependencies
       run: |
@@ -174,4 +172,3 @@ jobs:
       with:
         user: __token__        
         password: ${{ secrets.PYPI_API_TOKEN }}
-        persist-credentials: false


### PR DESCRIPTION
### Motivation
- Remove `persist-credentials: false` entries that are only valid for `actions/checkout` since they are ignored on other actions, keeping the workflow file tidy and unambiguous.

### Description
- Removed `persist-credentials: false` from non-`checkout` steps in `.github/workflows/python-app.yml` (the `actions/setup-python` steps in `lint` and `build-and-publish` jobs and the `pypa/gh-action-pypi-publish` step) and retained it only on `actions/checkout` steps.

### Testing
- No automated tests were run because this is a CI workflow YAML cleanup that does not change runtime code behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e5833dc88328a00911bacd088c0d)