### PR TITLE
Flush stdout before raising severe findings exception in scan

### DIFF
--- a/ghast/cli.py
+++ b/ghast/cli.py
@@ -8,6 +8,7 @@ allowing users to scan GitHub Actions workflows for security issues.
 import copy
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, cast
 
@@ -219,6 +220,7 @@ def scan(
     severe_findings = sum(sev_counts.get(lvl, 0) for lvl in SEVERITY_LEVELS[threshold_index:])
 
     if severe_findings > 0:
+        sys.stdout.flush()
         raise click.ClickException("Severe findings detected")
 
 


### PR DESCRIPTION
### Motivation
- Prevent stderr/stdout interleaving when `scan()` prints the report to stdout and then raises a `click.ClickException`, which could cause the error line to appear mid-report.

### Description
- Add `import sys` and invoke `sys.stdout.flush()` immediately before raising `click.ClickException("Severe findings detected")` in `scan()` to ensure stdout is flushed first.

### Testing
- Ran `pytest -q ghast/tests/test_cli.py` and all tests passed (`23 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e59803e48328999faace9ce8da61)