### PR TITLE
Fix rule line/column lookups to use YAML position store

### DIFF
--- a/ghast/rules/base.py
+++ b/ghast/rules/base.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
 from ..core import Finding
+from ..utils.yaml_handler import get_position
 
 
 class Rule(ABC):
@@ -337,8 +338,8 @@ class StepRule(Rule):
                         "has no shell specified"
                     ),
                     file_path=file_path,
-                    line_number=step.get("__line__"),
-                    column=step.get("__column__"),
+                    line_number=get_position(step)[0],
+                    column=get_position(step)[1],
                     remediation="Add 'shell: bash' to this step",
                     can_fix=True,
                 )
@@ -373,8 +374,8 @@ class StepRule(Rule):
                             f"Step {step_idx+1} in job '{job_id}' uses unstable reference: {action}"
                         ),
                         file_path=file_path,
-                        line_number=step.get("__line__"),
-                        column=step.get("__column__"),
+                        line_number=get_position(step)[0],
+                        column=get_position(step)[1],
                         remediation="Pin the action to a specific commit SHA",
                         can_fix=False,
                         severity="HIGH",  # Unstable references are high risk
@@ -393,8 +394,8 @@ class StepRule(Rule):
                             f"commit SHA: {action}"
                         ),
                         file_path=file_path,
-                        line_number=step.get("__line__"),
-                        column=step.get("__column__"),
+                        line_number=get_position(step)[0],
+                        column=get_position(step)[1],
                         remediation="Pin to a specific commit SHA for better security",
                         can_fix=False,
                     )

--- a/ghast/rules/best_practices.py
+++ b/ghast/rules/best_practices.py
@@ -9,6 +9,7 @@ import re
 from typing import Any, Dict, List
 
 from ..core import Finding
+from ..utils.yaml_handler import get_position
 from .base import JobRule, Rule, StepRule, WorkflowRule
 
 
@@ -197,8 +198,8 @@ class DeprecatedActionsRule(StepRule):
                                 self.create_finding(
                                     message=f"Deprecated action '{action}' in job '{job_id}' step {step_idx+1}",
                                     file_path=file_path,
-                                    line_number=step.get("__line__"),
-                                    column=step.get("__column__"),
+                                    line_number=get_position(step)[0],
+                                    column=get_position(step)[1],
                                     remediation=f"Update to {replacement}",
                                     can_fix=True,
                                     context={
@@ -269,8 +270,8 @@ class ContinueOnErrorRule(Rule):
                     self.create_finding(
                         message=f"Job '{job_id}' has 'continue-on-error: true'",
                         file_path=file_path,
-                        line_number=job.get("__line__"),
-                        column=job.get("__column__"),
+                        line_number=get_position(job)[0],
+                        column=get_position(job)[1],
                     )
                 )
 
@@ -284,8 +285,8 @@ class ContinueOnErrorRule(Rule):
                         self.create_finding(
                             message=f"Step {step_idx+1} in job '{job_id}' has 'continue-on-error: true'",
                             file_path=file_path,
-                            line_number=step.get("__line__"),
-                            column=step.get("__column__"),
+                            line_number=get_position(step)[0],
+                            column=get_position(step)[1],
                         )
                     )
 
@@ -318,8 +319,8 @@ class ReusableWorkflowRule(Rule):
                         self.create_finding(
                             message=f"Reusable workflow in job '{job_id}' uses 'with' without defining 'inputs'",
                             file_path=file_path,
-                            line_number=job.get("__line__"),
-                            column=job.get("__column__"),
+                            line_number=get_position(job)[0],
+                            column=get_position(job)[1],
                         )
                     )
 

--- a/ghast/rules/security.py
+++ b/ghast/rules/security.py
@@ -8,6 +8,7 @@ import re
 from typing import Any, Dict, List
 
 from ..core import Finding
+from ..utils.yaml_handler import get_position
 from .base import Rule, StepRule, TokenRule, WorkflowRule
 
 
@@ -54,8 +55,8 @@ class PermissionsRule(WorkflowRule):
                 self.create_finding(
                     message="Missing explicit permissions at workflow level",
                     file_path=file_path,
-                    line_number=workflow.get("__line__") or 1,
-                    column=workflow.get("__column__") or 1,
+                    line_number=get_position(workflow)[0] or 1,
+                    column=get_position(workflow)[1] or 1,
                     can_fix=True,
                 )
             )
@@ -64,8 +65,8 @@ class PermissionsRule(WorkflowRule):
                 self.create_finding(
                     message="Overly permissive workflow permissions (write-all)",
                     file_path=file_path,
-                    line_number=workflow.get("__line__") or 1,
-                    column=workflow.get("__column__") or 1,
+                    line_number=get_position(workflow)[0] or 1,
+                    column=get_position(workflow)[1] or 1,
                 )
             )
 
@@ -84,8 +85,8 @@ class PermissionsRule(WorkflowRule):
                 self.create_finding(
                     message=f"Missing explicit permissions in job '{job_id}'",
                     file_path=file_path,
-                    line_number=job.get("__line__") or 1,
-                    column=job.get("__column__") or 1,
+                    line_number=get_position(job)[0] or 1,
+                    column=get_position(job)[1] or 1,
                     can_fix=True,
                 )
             )
@@ -94,8 +95,8 @@ class PermissionsRule(WorkflowRule):
                 self.create_finding(
                     message=f"Job '{job_id}' has overly permissive permissions (write-all)",
                     file_path=file_path,
-                    line_number=job.get("__line__") or 1,
-                    column=job.get("__column__") or 1,
+                    line_number=get_position(job)[0] or 1,
+                    column=get_position(job)[1] or 1,
                 )
             )
 
@@ -336,8 +337,8 @@ class EnvironmentInjectionRule(StepRule):
                                     "does not disable credential persistence"
                                 ),
                                 file_path=file_path,
-                                line_number=step.get("__line__"),
-                                column=step.get("__column__"),
+                                line_number=get_position(step)[0],
+                                column=get_position(step)[1],
                                 remediation=(
                                     "Add 'persist-credentials: false' to the 'with' section of actions/checkout steps"
                                 ),
@@ -427,8 +428,8 @@ class TokenSecurityRule(TokenRule):
                                     "does not disable credential persistence"
                                 ),
                                 file_path=file_path,
-                                line_number=step.get("__line__"),
-                                column=step.get("__column__"),
+                                line_number=get_position(step)[0],
+                                column=get_position(step)[1],
                                 remediation=(
                                     "Add 'persist-credentials: false' to the 'with' section of actions/checkout steps"
                                 ),


### PR DESCRIPTION
### Motivation
- The YAML loader was refactored to store node positions externally which made `obj.get("__line__")` / `obj.get("__column__")` return `None`, so rule findings lost correct location info and some behaviors broke. 

### Description
- Added `from ..utils.yaml_handler import get_position` to `ghast/rules/security.py`, `ghast/rules/best_practices.py`, and `ghast/rules/base.py`.
- Replaced occurrences of `obj.get("__line__")` and `obj.get("__column__")` with `get_position(obj)[0]` and `get_position(obj)[1]` respectively in those three files so `create_finding` receives real YAML positions.
- Preserved existing fallbacks where code previously used `or 1` for top-level workflow/job defaults and did not change other rule logic.

### Testing
- Ran the test suite with `pytest -q`.
- Result: `170 passed, 1 failed` with the single failing test `ghast/tests/core/test_scanner.py::test_scan_file_matches_rule_engine_findings` due to updated position values returned by `get_position` compared to the previous `__line__`/`__column__` behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e55c9e4483289c1d87ec211d282b)