### PR TITLE
Remove import-time mock-execution shim and update module execution test

### DIFF
--- a/ghast/__init__.py
+++ b/ghast/__init__.py
@@ -1,7 +1,3 @@
-_previous_main = globals().get("main")
-if callable(_previous_main) and _previous_main.__class__.__module__.startswith("unittest.mock"):
-    _previous_main()
-
 """
 ghast - GitHub Actions Security Tool
 

--- a/ghast/tests/test_main.py
+++ b/ghast/tests/test_main.py
@@ -2,8 +2,8 @@
 test_main.py - Tests for the main package functionality
 """
 
-import pytest
 from unittest.mock import patch
+from pathlib import Path
 
 import ghast
 
@@ -50,10 +50,16 @@ def test_main_function():
 
 def test_module_execution():
     """Test direct module execution."""
-    with patch("ghast.main") as mock_main:
-        with patch("ghast.__name__", "__main__"):
+    init_path = Path(ghast.__file__)
 
-            import importlib
+    with patch("ghast.cli.cli") as mock_cli:
+        module_globals = {
+            "__name__": "__main__",
+            "__file__": str(init_path),
+            "__package__": "ghast",
+            "__spec__": None,
+            "__builtins__": __builtins__,
+        }
+        exec(init_path.read_text(), module_globals)
 
-            importlib.reload(ghast)
-            mock_main.assert_called_once()
+        mock_cli.assert_called_once()


### PR DESCRIPTION
### Motivation
- The package contained an import-time shim that invoked a mocked `main` when a mock was present, which caused mock objects to run at import time in production contexts. 
- The test previously relied on `importlib.reload` and the shim to assert module execution, so the test was rewritten to assert behavior without reloading the package.

### Description
- Deleted the mock-execution shim from `ghast/__init__.py` that called a `main` object found in `globals()` when it appeared to be a `unittest.mock` object. 
- Kept the normal CLI entry behavior (`if __name__ == "__main__": main()`) intact. 
- Reworked `ghast/tests/test_main.py` by removing the `importlib.reload` approach and instead executing `ghast/__init__.py` via `exec()` with a controlled `__main__`-like `module_globals` mapping while patching `ghast.cli.cli`. 
- Adjusted imports in the test (`Path` usage) and changed the patch target to `ghast.cli.cli` to assert CLI invocation.

### Testing
- Ran `pytest -q ghast/tests/test_main.py`, which completed successfully with `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e7e641c4832880a467a32e143976)