### PR TITLE
Fix rule position lookups to use get_position

### DIFF
--- a/ghast/rules/base.py
+++ b/ghast/rules/base.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
 from ..core import Finding
+from ..utils.yaml_handler import get_position
 
 
 def _is_false(value: Any) -> bool:
@@ -347,8 +348,8 @@ class StepRule(Rule):
                         "has no shell specified"
                     ),
                     file_path=file_path,
-                    line_number=step.get("__line__"),
-                    column=step.get("__column__"),
+                    line_number=get_position(step)[0],
+                    column=get_position(step)[1],
                     remediation="Add 'shell: bash' to this step",
                     can_fix=True,
                 )
@@ -383,8 +384,8 @@ class StepRule(Rule):
                             f"Step {step_idx+1} in job '{job_id}' uses unstable reference: {action}"
                         ),
                         file_path=file_path,
-                        line_number=step.get("__line__"),
-                        column=step.get("__column__"),
+                        line_number=get_position(step)[0],
+                        column=get_position(step)[1],
                         remediation="Pin the action to a specific commit SHA",
                         can_fix=False,
                         severity="HIGH",  # Unstable references are high risk
@@ -403,8 +404,8 @@ class StepRule(Rule):
                             f"commit SHA: {action}"
                         ),
                         file_path=file_path,
-                        line_number=step.get("__line__"),
-                        column=step.get("__column__"),
+                        line_number=get_position(step)[0],
+                        column=get_position(step)[1],
                         remediation="Pin to a specific commit SHA for better security",
                         can_fix=False,
                     )

--- a/ghast/rules/best_practices.py
+++ b/ghast/rules/best_practices.py
@@ -9,6 +9,7 @@ import re
 from typing import Any, Dict, List
 
 from ..core import Finding
+from ..utils.yaml_handler import get_position
 from .base import JobRule, Rule, StepRule, WorkflowRule, _is_true
 
 
@@ -197,8 +198,8 @@ class DeprecatedActionsRule(StepRule):
                                 self.create_finding(
                                     message=f"Deprecated action '{action}' in job '{job_id}' step {step_idx+1}",
                                     file_path=file_path,
-                                    line_number=step.get("__line__"),
-                                    column=step.get("__column__"),
+                                    line_number=get_position(step)[0],
+                                    column=get_position(step)[1],
                                     remediation=f"Update to {replacement}",
                                     can_fix=True,
                                     context={
@@ -269,8 +270,8 @@ class ContinueOnErrorRule(Rule):
                     self.create_finding(
                         message=f"Job '{job_id}' has 'continue-on-error: true'",
                         file_path=file_path,
-                        line_number=job.get("__line__"),
-                        column=job.get("__column__"),
+                        line_number=get_position(job)[0],
+                        column=get_position(job)[1],
                     )
                 )
 
@@ -284,8 +285,8 @@ class ContinueOnErrorRule(Rule):
                         self.create_finding(
                             message=f"Step {step_idx+1} in job '{job_id}' has 'continue-on-error: true'",
                             file_path=file_path,
-                            line_number=step.get("__line__"),
-                            column=step.get("__column__"),
+                            line_number=get_position(step)[0],
+                            column=get_position(step)[1],
                         )
                     )
 
@@ -318,8 +319,8 @@ class ReusableWorkflowRule(Rule):
                         self.create_finding(
                             message=f"Reusable workflow in job '{job_id}' uses 'with' without defining 'inputs'",
                             file_path=file_path,
-                            line_number=job.get("__line__"),
-                            column=job.get("__column__"),
+                            line_number=get_position(job)[0],
+                            column=get_position(job)[1],
                         )
                     )
 

--- a/ghast/rules/security.py
+++ b/ghast/rules/security.py
@@ -8,6 +8,7 @@ import re
 from typing import Any, Dict, List
 
 from ..core import Finding
+from ..utils.yaml_handler import get_position
 from .base import Rule, StepRule, TokenRule, WorkflowRule, _is_false
 
 
@@ -54,8 +55,8 @@ class PermissionsRule(WorkflowRule):
                 self.create_finding(
                     message="Missing explicit permissions at workflow level",
                     file_path=file_path,
-                    line_number=workflow.get("__line__") or 1,
-                    column=workflow.get("__column__") or 1,
+                    line_number=get_position(workflow)[0] or 1,
+                    column=get_position(workflow)[1] or 1,
                     can_fix=True,
                 )
             )
@@ -64,8 +65,8 @@ class PermissionsRule(WorkflowRule):
                 self.create_finding(
                     message="Overly permissive workflow permissions (write-all)",
                     file_path=file_path,
-                    line_number=workflow.get("__line__") or 1,
-                    column=workflow.get("__column__") or 1,
+                    line_number=get_position(workflow)[0] or 1,
+                    column=get_position(workflow)[1] or 1,
                 )
             )
 
@@ -84,8 +85,8 @@ class PermissionsRule(WorkflowRule):
                 self.create_finding(
                     message=f"Missing explicit permissions in job '{job_id}'",
                     file_path=file_path,
-                    line_number=job.get("__line__") or 1,
-                    column=job.get("__column__") or 1,
+                    line_number=get_position(job)[0] or 1,
+                    column=get_position(job)[1] or 1,
                     can_fix=True,
                 )
             )
@@ -94,8 +95,8 @@ class PermissionsRule(WorkflowRule):
                 self.create_finding(
                     message=f"Job '{job_id}' has overly permissive permissions (write-all)",
                     file_path=file_path,
-                    line_number=job.get("__line__") or 1,
-                    column=job.get("__column__") or 1,
+                    line_number=get_position(job)[0] or 1,
+                    column=get_position(job)[1] or 1,
                 )
             )
 
@@ -336,8 +337,8 @@ class EnvironmentInjectionRule(StepRule):
                                     "does not disable credential persistence"
                                 ),
                                 file_path=file_path,
-                                line_number=step.get("__line__"),
-                                column=step.get("__column__"),
+                                line_number=get_position(step)[0],
+                                column=get_position(step)[1],
                                 remediation=(
                                     "Add 'persist-credentials: false' to the 'with' section of actions/checkout steps"
                                 ),
@@ -427,8 +428,8 @@ class TokenSecurityRule(TokenRule):
                                     "does not disable credential persistence"
                                 ),
                                 file_path=file_path,
-                                line_number=step.get("__line__"),
-                                column=step.get("__column__"),
+                                line_number=get_position(step)[0],
+                                column=get_position(step)[1],
                                 remediation=(
                                     "Add 'persist-credentials: false' to the 'with' section of actions/checkout steps"
                                 ),

--- a/ghast/utils/yaml_handler.py
+++ b/ghast/utils/yaml_handler.py
@@ -56,7 +56,9 @@ def get_position(node_or_path: Any, root: Optional[Any] = None) -> Position:
             return _paths_by_root_id.get(root_id, {}).get(tuple(node_or_path), (None, None))
         return _positions_by_root_id.get(root_id, {}).get(id(node_or_path), (None, None))
 
-    for positions in _positions_by_root_id.values():
+    # Prefer the most recently parsed root to avoid stale matches when Python
+    # reuses object IDs across different YAML loads.
+    for positions in reversed(list(_positions_by_root_id.values())):
         found = positions.get(id(node_or_path))
         if found is not None:
             return found


### PR DESCRIPTION
### Motivation
- The YAML loader now stores source positions externally in `_positions_by_root_id`, so reading `__line__`/`__column__` directly from workflow/job/step objects returns `None` and produced incorrect location metadata.
- Rules need to obtain positions via the shared helper to produce accurate finding line/column information.

### Description
- Replaced all object `.get("__line__")` and `.get("__column__")` usages with `get_position(obj)[0]` and `get_position(obj)[1]` in `ghast/rules/security.py`, `ghast/rules/best_practices.py`, and `ghast/rules/base.py` to read positions from the external store.
- Added `from ..utils.yaml_handler import get_position` imports to each of the three modified modules.
- Updated finding creation paths that report workflow/job/step locations (e.g., `PermissionsRule`, deprecated-action checks, continue-on-error detections, step pinning/shell checks, token/checkout checks) to use the new position accessor.

### Testing
- Compiled the modified modules with `python -m compileall ghast/rules/security.py ghast/rules/best_practices.py ghast/rules/base.py` and confirmed bytecode compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e90769f48328b43718f99fae5a0b)