### PR TITLE
Restore reusable workflow_call input reference validation

### DIFF
--- a/ghast/rules/best_practices.py
+++ b/ghast/rules/best_practices.py
@@ -296,6 +296,8 @@ class ContinueOnErrorRule(Rule):
 class ReusableWorkflowRule(Rule):
     """Rule for checking reusable workflow inputs"""
 
+    INPUT_REFERENCE_PATTERN = re.compile(r"\binputs\.([A-Za-z_][A-Za-z0-9_-]*)")
+
     def __init__(self) -> None:
         super().__init__(
             rule_id="reusable_workflow_inputs",
@@ -304,6 +306,23 @@ class ReusableWorkflowRule(Rule):
             remediation="Define explicit 'inputs' for reusable workflows",
             category="best-practice",
         )
+
+    def _collect_input_references(self, node: Any, refs: List[Dict[str, Any]]) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key in ("__line__", "__column__"):
+                    continue
+                self._collect_input_references(value, refs)
+            return
+
+        if isinstance(node, list):
+            for item in node:
+                self._collect_input_references(item, refs)
+            return
+
+        if isinstance(node, str):
+            for match in self.INPUT_REFERENCE_PATTERN.finditer(node):
+                refs.append({"name": match.group(1), "node": node})
 
     def check(self, workflow: Dict[str, Any], file_path: str) -> List[Finding]:
         """Check for reusable workflow input issues"""
@@ -323,5 +342,46 @@ class ReusableWorkflowRule(Rule):
                             column=get_position(job)[1],
                         )
                     )
+
+        on_section = workflow.get("on", workflow.get(True, {}))
+        if not isinstance(on_section, dict):
+            return findings
+
+        if "workflow_call" not in on_section:
+            return findings
+        trigger = on_section.get("workflow_call") or {}
+        if not isinstance(trigger, dict):
+            trigger = {}
+
+        declared_inputs = trigger.get("inputs")
+        if declared_inputs is None:
+            declared_inputs = {}
+        if not isinstance(declared_inputs, dict):
+            declared_inputs = {}
+
+        references: List[Dict[str, Any]] = []
+        self._collect_input_references(workflow.get("jobs", {}), references)
+
+        if references and not declared_inputs:
+            findings.append(
+                self.create_finding(
+                    message="Reusable workflow references inputs but does not define on.workflow_call.inputs",
+                    file_path=file_path,
+                    line_number=get_position(trigger)[0],
+                    column=get_position(trigger)[1],
+                )
+            )
+            return findings
+
+        missing = sorted({ref["name"] for ref in references if ref["name"] not in declared_inputs})
+        for name in missing:
+            findings.append(
+                self.create_finding(
+                    message=f"Reusable workflow references undeclared input '{name}'",
+                    file_path=file_path,
+                    line_number=get_position(trigger)[0],
+                    column=get_position(trigger)[1],
+                )
+            )
 
         return findings

--- a/ghast/tests/core/test_scanner.py
+++ b/ghast/tests/core/test_scanner.py
@@ -222,7 +222,7 @@ jobs:
 
 
 def test_check_reusable_inputs_missing_mapping(temp_dir):
-    """Referencing inputs without declaring the inputs mapping should be flagged."""
+    """Referencing inputs without declaring on.workflow_call.inputs should be flagged."""
 
     workflow_path = _write_temp_workflow(
         temp_dir,
@@ -241,7 +241,8 @@ jobs:
 
     findings = _run_rule("reusable_workflow_inputs", workflow, str(workflow_path))
 
-    assert findings == []
+    assert len(findings) == 1
+    assert "does not define on.workflow_call.inputs" in findings[0].message
 
 
 def test_check_reusable_inputs_missing_declaration(temp_dir):
@@ -267,7 +268,8 @@ jobs:
 
     findings = _run_rule("reusable_workflow_inputs", workflow, str(workflow_path))
 
-    assert findings == []
+    assert len(findings) == 1
+    assert "undeclared input 'missing'" in findings[0].message
 
 
 def test_check_reusable_inputs_handles_mixed_position_types(monkeypatch):
@@ -299,7 +301,8 @@ def test_check_reusable_inputs_handles_mixed_position_types(monkeypatch):
 
     findings = _run_rule("reusable_workflow_inputs", workflow, "reusable.yml")
 
-    assert findings == []
+    assert len(findings) == 1
+    assert "undeclared input 'missing'" in findings[0].message
 
 
 def test_check_ppe_vulnerabilities(insecure_workflow_file):


### PR DESCRIPTION
### Motivation
- Re-enable validation for reusable workflow callees that reference `inputs` inside their jobs so improper or missing `on.workflow_call.inputs` are detected. 
- The previous scanner change left tests effectively asserting a no-op behavior; tests were updated to reflect the restored validation.

### Description
- Added `INPUT_REFERENCE_PATTERN` and a helper `_collect_input_references` to `ReusableWorkflowRule` to locate `${{ inputs.NAME }}` references across job/step nodes in `ghast/rules/best_practices.py`.
- Extended `ReusableWorkflowRule.check` to normalize the `on` section (including YAML boolean `True` key cases), inspect `on.workflow_call`, and produce findings when `workflow_call.inputs` is missing or when referenced input names are undeclared, while preserving the existing caller-side `uses` + `with` without `inputs` check.
- Updated tests in `ghast/tests/core/test_scanner.py` to assert the restored behavior for missing `on.workflow_call.inputs`, missing declarations, and the mixed-position scenario.

### Testing
- Ran the focused test set: `pytest -q ghast/tests/core/test_scanner.py::test_check_reusable_inputs_with_declared_inputs ghast/tests/core/test_scanner.py::test_check_reusable_inputs_missing_mapping ghast/tests/core/test_scanner.py::test_check_reusable_inputs_missing_declaration ghast/tests/core/test_scanner.py::test_check_reusable_inputs_handles_mixed_position_types ghast/tests/rules/test_best_practices.py::test_reusable_workflow_rule`.
- All tests in that set passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ee34aa7c8328ab81bbf6cabef0a0)