### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main ]
     paths-ignore:
       - '**.md'
-      - 'docs/**'
   pull_request:
     branches: [ main ]
     paths-ignore:
@@ -116,6 +115,45 @@ jobs:
       run: |
         ghast scan . --severity-threshold MEDIUM
       shell: bash
+
+
+  deploy-pages:
+    name: Deploy GitHub Pages
+    runs-on: ubuntu-latest
+    needs: [test, lint, self-check]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    concurrency:
+      group: github-pages
+      cancel-in-progress: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
+      with:
+        persist-credentials: false
+
+    - name: Configure GitHub Pages
+      uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
+    - name: Upload Pages artifact
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+      with:
+        path: docs
+
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   build-and-publish:
     name: Build and publish Python distributions


### PR DESCRIPTION
### Motivation
- Allow the repository `docs` site to be published automatically when changes are pushed to `main` so documentation updates are deployed. 
- Ensure Pages deployment runs only after CI (`test`, `lint`, `self-check`) to avoid publishing broken docs. 
- Use pinned action SHAs and minimal scoped permissions to keep the deployment reproducible and limited in privileges.

### Description
- Update `on.push` in `.github/workflows/python-app.yml` to stop ignoring `docs/**` so docs changes can trigger deploys. 
- Add a `deploy-pages` job to `.github/workflows/python-app.yml` that runs on pushes to `main`, depends on `test`, `lint`, and `self-check`, and includes `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`. 
- Configure the job permissions to `contents: read`, `pages: write`, and `id-token: write`, set an `environment` with the `page_url` output, and add `concurrency` protection. 
- Implement steps to `checkout`, run `actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b`, `actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa` with `path: docs`, and `actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e`.

### Testing
- Verified workflow YAML parsing with `python -c` + `yaml.safe_load(...)` and inspected `jobs.deploy-pages` values, which succeeded. 
- Ran `ghast scan . --severity-threshold MEDIUM` after installing the package with `python -m pip install -e .` and the scan reported no issues. 
- Ran `pytest ghast/tests/` and all tests passed (`171 passed`). 
- Ran `actionlint .github/workflows/python-app.yml` and `git diff --check` and both reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ad5fecaf88328a35568412632f3e2)