### PR TITLE
Add comprehensive edge-case test coverage and 100% code coverage

### DIFF
--- a/ghast/__init__.py
+++ b/ghast/__init__.py
@@ -60,5 +60,5 @@ if "main" not in globals():
         cli()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/ghast/cli.py
+++ b/ghast/cli.py
@@ -499,5 +499,5 @@ def report(repo_path: str, output: str, format: str) -> None:
     click.echo(f"Report generated at: {output}")
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     cli()

--- a/ghast/reports/report.py
+++ b/ghast/reports/report.py
@@ -178,7 +178,10 @@ def generate_html_report(
     findings: List[Finding], stats: Dict[str, Any], repo_path: Optional[str] = None
 ) -> str:
     """
-    Generate an HTML report (placeholder for future implementation)
+    Generate a self-contained HTML report
+
+    Renders the summary statistics as a table and embeds the full text report
+    (HTML-escaped) for detailed findings.
 
     Args:
         findings: List of findings

--- a/ghast/tests/core/test_config_edge.py
+++ b/ghast/tests/core/test_config_edge.py
@@ -1,0 +1,139 @@
+"""
+test_config_edge.py - Edge-case coverage for configuration management
+
+Covers enum/list serialization, the validation error branches, config auto
+discovery (empty/unreadable/invalid/valid files), and save/generate failures.
+"""
+
+import os
+
+import pytest
+import yaml
+
+from ghast.core import config as config_module
+from ghast.core.config import (
+    ConfigurationError,
+    _serialize_enums,
+    generate_default_config,
+    load_config,
+    save_config,
+    validate_config,
+)
+from ghast.core.scanner import Severity
+
+
+def test_serialize_enums_handles_lists_and_enums():
+    obj = {"levels": [Severity.LOW, Severity.HIGH], "nested": {"sev": Severity.CRITICAL}}
+    result = _serialize_enums(obj)
+    assert result == {"levels": ["LOW", "HIGH"], "nested": {"sev": "CRITICAL"}}
+
+
+def test_validate_severity_thresholds_not_dict():
+    with pytest.raises(ConfigurationError, match="severity_thresholds"):
+        validate_config({"severity_thresholds": "not-a-dict"})
+
+
+def test_validate_auto_fix_enabled_not_bool():
+    with pytest.raises(ConfigurationError, match="auto_fix.enabled"):
+        validate_config({"auto_fix": {"enabled": "yes"}})
+
+
+def test_validate_auto_fix_rules_not_dict():
+    with pytest.raises(ConfigurationError, match="auto_fix.rules"):
+        validate_config({"auto_fix": {"rules": "nope"}})
+
+
+def test_validate_defaults_timeout_not_int():
+    with pytest.raises(ConfigurationError, match="default_timeout_minutes"):
+        validate_config({"default_timeout_minutes": "abc"})
+
+
+def test_validate_defaults_action_versions_not_dict():
+    with pytest.raises(ConfigurationError, match="default_action_versions"):
+        validate_config({"default_action_versions": "nope"})
+
+
+def test_load_config_explicit_path_invalid(tmp_path):
+    bad = tmp_path / "ghast.yml"
+    bad.write_text("totally_unknown_key: true\n")
+    with pytest.raises(ConfigurationError, match="Error loading configuration"):
+        load_config(str(bad))
+
+
+def test_load_config_autodiscovery_skips_unreadable(monkeypatch, tmp_path):
+    # A directory cannot be opened with open(..., "r") -> OSError -> skipped.
+    a_dir = tmp_path / "ghast.yml"
+    a_dir.mkdir()
+    monkeypatch.setattr(config_module, "get_config_paths", lambda: [str(a_dir)])
+    cfg = load_config()
+    # Falls back to defaults.
+    assert cfg["check_timeout"] is True
+
+
+def test_load_config_autodiscovery_skips_empty(monkeypatch, tmp_path):
+    empty = tmp_path / "ghast.yml"
+    empty.write_text("")
+    monkeypatch.setattr(config_module, "get_config_paths", lambda: [str(empty)])
+    cfg = load_config()
+    assert cfg["check_timeout"] is True
+
+
+def test_load_config_autodiscovery_invalid_raises(monkeypatch, tmp_path):
+    bad = tmp_path / "ghast.yml"
+    bad.write_text("unknown_option: true\n")
+    monkeypatch.setattr(config_module, "get_config_paths", lambda: [str(bad)])
+    with pytest.raises(ConfigurationError, match="Unknown configuration option"):
+        load_config()
+
+
+def test_load_config_autodiscovery_unexpected_validation_error(monkeypatch, tmp_path):
+    good = tmp_path / "ghast.yml"
+    good.write_text("check_timeout: false\n")
+    monkeypatch.setattr(config_module, "get_config_paths", lambda: [str(good)])
+
+    def _boom(_cfg):
+        raise ValueError("unexpected")
+
+    monkeypatch.setattr(config_module, "validate_config", _boom)
+    with pytest.raises(ConfigurationError, match="Error validating configuration"):
+        load_config()
+
+
+def test_load_config_autodiscovery_valid(monkeypatch, tmp_path):
+    good = tmp_path / "ghast.yml"
+    good.write_text("check_timeout: false\n")
+    monkeypatch.setattr(config_module, "get_config_paths", lambda: [str(good)])
+    cfg = load_config()
+    assert cfg["check_timeout"] is False
+
+
+def test_load_config_autodiscovery_yaml_error(monkeypatch, tmp_path):
+    bad = tmp_path / "ghast.yml"
+    bad.write_text("key: [unclosed\n")
+    monkeypatch.setattr(config_module, "get_config_paths", lambda: [str(bad)])
+    with pytest.raises(ConfigurationError, match="Error parsing YAML"):
+        load_config()
+
+
+def test_save_config_failure(monkeypatch, tmp_path):
+    def _boom(*args, **kwargs):
+        raise RuntimeError("dump failed")
+
+    monkeypatch.setattr(config_module.yaml, "dump", _boom)
+    with pytest.raises(ConfigurationError, match="Error saving configuration"):
+        save_config({"check_timeout": True}, str(tmp_path / "out.yml"))
+
+
+def test_generate_default_config_write_failure(monkeypatch, tmp_path):
+    target = tmp_path / "default.yml"
+
+    real_open = open
+
+    def _boom(path, *args, **kwargs):
+        if str(path) == str(target):
+            raise OSError("cannot write")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", _boom)
+    with pytest.raises(ConfigurationError, match="Error saving default configuration"):
+        generate_default_config(str(target))

--- a/ghast/tests/core/test_fixer_edge.py
+++ b/ghast/tests/core/test_fixer_edge.py
@@ -1,0 +1,237 @@
+"""
+test_fixer_edge.py - Edge-case coverage for the auto-remediation module
+
+Covers fixer fall-through branches, interactive prompting, error handling
+during fixing/dumping, fix_runs_on, and the fix_repository skip/echo paths.
+"""
+
+import os
+import shutil
+
+import click
+import pytest
+import yaml
+
+from ghast.core import Finding
+from ghast.core import fixer as fixer_module
+from ghast.core.fixer import Fixer, fix_repository
+
+
+def _copy(src, dst_dir, name):
+    dst = os.path.join(dst_dir, name)
+    shutil.copy2(src, dst)
+    return dst
+
+
+def _timeout_finding(file_path, message="Job 'build' has 6 steps but no timeout-minutes set"):
+    return Finding(
+        rule_id="check_timeout",
+        severity="LOW",
+        message=message,
+        file_path=file_path,
+        remediation="Add timeout",
+        can_fix=True,
+    )
+
+
+def test_fix_workflow_file_no_fixable_findings(patchable_workflow_file, temp_dir):
+    test_file = _copy(patchable_workflow_file, temp_dir, "nofix.yml")
+    # rule_id is not among the registered fixers.
+    findings = [
+        Finding(
+            rule_id="check_tokens",
+            severity="HIGH",
+            message="hardcoded token",
+            file_path=test_file,
+            can_fix=True,
+        )
+    ]
+    assert Fixer({}).fix_workflow_file(test_file, findings) == (0, 0)
+
+
+def test_fix_workflow_file_missing_fixer_func(patchable_workflow_file, temp_dir):
+    test_file = _copy(patchable_workflow_file, temp_dir, "missingfixer.yml")
+
+    class _ContainsButNoGet(dict):
+        def get(self, key, default=None):
+            return None
+
+    fixer = Fixer({})
+    # Passes the membership filter but resolves to no fixer function.
+    fixer.fixers = _ContainsButNoGet({"check_timeout": fixer.fix_timeout})
+    applied, skipped = fixer.fix_workflow_file(test_file, [_timeout_finding(test_file)])
+    assert applied == 0
+    assert skipped == 1
+    # No fixes applied -> backup is cleaned up.
+    assert not os.path.exists(f"{test_file}.bak")
+
+
+def test_fix_workflow_file_interactive_confirm(patchable_workflow_file, temp_dir, monkeypatch):
+    test_file = _copy(patchable_workflow_file, temp_dir, "interactive_yes.yml")
+    monkeypatch.setattr(click, "confirm", lambda *a, **k: True)
+    fixer = Fixer({}, interactive=True)
+    applied, skipped = fixer.fix_workflow_file(test_file, [_timeout_finding(test_file)])
+    assert applied == 1
+
+
+def test_fix_workflow_file_interactive_decline(patchable_workflow_file, temp_dir, monkeypatch):
+    test_file = _copy(patchable_workflow_file, temp_dir, "interactive_no.yml")
+    monkeypatch.setattr(click, "confirm", lambda *a, **k: False)
+    fixer = Fixer({}, interactive=True)
+    applied, skipped = fixer.fix_workflow_file(test_file, [_timeout_finding(test_file)])
+    assert applied == 0
+    assert skipped == 1
+
+
+def test_fix_workflow_file_fixer_returns_false(patchable_workflow_file, temp_dir):
+    test_file = _copy(patchable_workflow_file, temp_dir, "returnsfalse.yml")
+    # Message without a recognisable "Job '...'" so fix_timeout returns False.
+    finding = _timeout_finding(test_file, message="unmatchable message")
+    applied, skipped = Fixer({}).fix_workflow_file(test_file, [finding])
+    assert applied == 0
+    assert skipped == 1
+
+
+def test_fix_workflow_file_fixer_raises(patchable_workflow_file, temp_dir, capsys):
+    test_file = _copy(patchable_workflow_file, temp_dir, "raises.yml")
+
+    def _boom(workflow, finding):
+        raise RuntimeError("kaboom")
+
+    fixer = Fixer({})
+    fixer.fixers["check_timeout"] = _boom
+    applied, skipped = fixer.fix_workflow_file(test_file, [_timeout_finding(test_file)])
+    assert applied == 0
+    assert skipped == 1
+    assert "Error fixing" in capsys.readouterr().err
+
+
+def test_fix_workflow_file_dump_error_restores(
+    patchable_workflow_file, temp_dir, monkeypatch, capsys
+):
+    test_file = _copy(patchable_workflow_file, temp_dir, "dumperror.yml")
+    with open(test_file, "r") as f:
+        original = f.read()
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("dump failed")
+
+    monkeypatch.setattr(fixer_module.yaml, "dump", _boom)
+    applied, skipped = Fixer({}).fix_workflow_file(test_file, [_timeout_finding(test_file)])
+    assert (applied, skipped) == (0, 0)
+    # Original content restored, backup removed.
+    with open(test_file, "r") as f:
+        assert f.read() == original
+    assert not os.path.exists(f"{test_file}.bak")
+    assert "Error fixing" in capsys.readouterr().err
+
+
+# --- direct fixer-method fall-through paths -----------------------------------
+
+
+def test_fix_timeout_no_match():
+    assert Fixer({}).fix_timeout({"jobs": {}}, _timeout_finding("f", message="nope")) is False
+
+
+def test_fix_timeout_unknown_job():
+    finding = _timeout_finding("f", message="Job 'ghost' has 6 steps")
+    assert Fixer({}).fix_timeout({"jobs": {"build": {}}}, finding) is False
+
+
+def test_fix_shell_no_match():
+    finding = Finding(rule_id="check_shell", severity="LOW", message="nope", file_path="f")
+    assert Fixer({}).fix_shell({"jobs": {}}, finding) is False
+
+
+def test_fix_shell_unknown_job():
+    finding = Finding(
+        rule_id="check_shell",
+        severity="LOW",
+        message="Multiline script in job 'ghost' step 1 has no shell specified",
+        file_path="f",
+    )
+    assert Fixer({}).fix_shell({"jobs": {"build": {}}}, finding) is False
+
+
+def test_fix_deprecated_no_match():
+    finding = Finding(rule_id="check_deprecated", severity="MEDIUM", message="nope", file_path="f")
+    assert Fixer({}).fix_deprecated_actions({"jobs": {}}, finding) is False
+
+
+def test_fix_deprecated_no_replacement():
+    finding = Finding(
+        rule_id="check_deprecated",
+        severity="MEDIUM",
+        message="Deprecated action 'actions/unknown@v1' in job 'build' step 1",
+        file_path="f",
+    )
+    assert Fixer({}).fix_deprecated_actions({"jobs": {"build": {}}}, finding) is False
+
+
+def test_fix_deprecated_no_matching_step():
+    finding = Finding(
+        rule_id="check_deprecated",
+        severity="MEDIUM",
+        message="Deprecated action 'actions/checkout@v1' in job 'build' step 1",
+        file_path="f",
+    )
+    config = {"default_action_versions": {"actions/checkout@v1": "actions/checkout@v3"}}
+    workflow = {"jobs": {"build": {"steps": [{"uses": "actions/setup-node@v3"}]}}}
+    assert Fixer(config).fix_deprecated_actions(workflow, finding) is False
+
+
+def _runs_on_finding(message="Missing 'runs-on' in job 'build'"):
+    return Finding(rule_id="check_runs_on", severity="MEDIUM", message=message, file_path="f")
+
+
+def test_fix_runs_on_adds_runner():
+    workflow = {"jobs": {"build": {"steps": []}}}
+    assert Fixer({}).fix_runs_on(workflow, _runs_on_finding()) is True
+    assert workflow["jobs"]["build"]["runs-on"] == "ubuntu-latest"
+
+
+def test_fix_runs_on_no_match():
+    assert Fixer({}).fix_runs_on({"jobs": {}}, _runs_on_finding(message="nope")) is False
+
+
+def test_fix_runs_on_unknown_job():
+    finding = _runs_on_finding(message="Missing 'runs-on' in job 'ghost'")
+    assert Fixer({}).fix_runs_on({"jobs": {"build": {}}}, finding) is False
+
+
+def test_fix_runs_on_already_present():
+    workflow = {"jobs": {"build": {"runs-on": "ubuntu-latest"}}}
+    assert Fixer({}).fix_runs_on(workflow, _runs_on_finding()) is False
+
+
+# --- fix_repository skip/echo paths -------------------------------------------
+
+
+def test_fix_repository_skips_empty_and_unfixable(patchable_workflow_file, temp_dir):
+    empty_file = _copy(patchable_workflow_file, temp_dir, "empty.yml")
+    unfixable_file = _copy(patchable_workflow_file, temp_dir, "unfixable.yml")
+    findings_by_file = {
+        empty_file: [],
+        unfixable_file: [
+            Finding(
+                rule_id="check_tokens",
+                severity="HIGH",
+                message="token",
+                file_path=unfixable_file,
+                can_fix=True,
+            )
+        ],
+    }
+    applied, skipped = fix_repository(temp_dir, findings_by_file, {})
+    assert applied == 0
+    assert skipped == 0
+
+
+def test_fix_repository_echoes_skipped(patchable_workflow_file, temp_dir, capsys):
+    test_file = _copy(patchable_workflow_file, temp_dir, "skipme.yml")
+    # Fixable rule but unmatchable message -> fixer returns False -> skipped.
+    findings_by_file = {test_file: [_timeout_finding(test_file, message="unmatchable")]}
+    applied, skipped = fix_repository(temp_dir, findings_by_file, {})
+    assert applied == 0
+    assert skipped == 1
+    assert "Skipped" in capsys.readouterr().out

--- a/ghast/tests/core/test_scanner_edge.py
+++ b/ghast/tests/core/test_scanner_edge.py
@@ -1,0 +1,53 @@
+"""
+test_scanner_edge.py - Edge-case coverage for the workflow scanner
+
+Covers the backward-compatibility shims, rule-id normalization for
+``rule_error.*`` findings, and the directory-scanning helper.
+"""
+
+from pathlib import Path
+
+from ghast.core import Finding
+from ghast.core.scanner import Severity, WorkflowScanner
+
+
+def test_register_rule_shim_is_noop():
+    scanner = WorkflowScanner()
+    # Should accept the legacy signature without raising or registering.
+    assert scanner.register_rule("custom", lambda w, f: [], severity="HIGH") is None
+
+
+def test_register_default_rules_shim_is_noop():
+    scanner = WorkflowScanner()
+    assert scanner.register_default_rules() is None
+
+
+def test_normalize_rule_ids_for_rule_error():
+    scanner = WorkflowScanner()
+    findings = [
+        Finding(rule_id="rule_error.permissions", severity="LOW", message="m", file_path="f"),
+        Finding(rule_id="rule_error.check_timeout", severity="LOW", message="m", file_path="f"),
+        Finding(rule_id="permissions", severity="HIGH", message="m", file_path="f"),
+        Finding(rule_id="check_timeout", severity="LOW", message="m", file_path="f"),
+    ]
+    normalized = scanner._normalize_rule_ids(findings)
+    ids = [f.rule_id for f in normalized]
+    assert ids == [
+        "rule_error.check_permissions",
+        "rule_error.check_timeout",
+        "check_permissions",
+        "check_timeout",
+    ]
+
+
+def test_scan_directory_without_workflows(temp_dir):
+    scanner = WorkflowScanner()
+    assert scanner.scan_directory(temp_dir) == []
+
+
+def test_scan_directory_with_workflows(insecure_workflow_file, temp_dir):
+    # insecure_workflow_file already lives under temp_dir/.github/workflows
+    scanner = WorkflowScanner()
+    findings = scanner.scan_directory(temp_dir, severity_threshold=Severity.LOW.value)
+    assert len(findings) > 0
+    assert all(isinstance(f, Finding) for f in findings)

--- a/ghast/tests/reports/test_report_edge.py
+++ b/ghast/tests/reports/test_report_edge.py
@@ -1,0 +1,51 @@
+"""
+test_report_edge.py - Edge-case coverage for report generation
+
+Covers the summary-only JSON path, the invalid-format error, and the
+duration-formatting fallbacks when timestamps are malformed.
+"""
+
+import json
+
+import pytest
+
+from ghast.reports.console import format_summary
+from ghast.reports.json import generate_json_summary
+from ghast.reports.report import generate_report
+
+
+def test_generate_report_summary_only_json(mock_findings, mock_stats):
+    output = generate_report(mock_findings, mock_stats, format="json", summary_only=True)
+    data = json.loads(output)
+    assert "summary" in data
+
+
+def test_generate_report_invalid_format(mock_findings, mock_stats):
+    with pytest.raises(ValueError, match="Invalid report format"):
+        generate_report(mock_findings, mock_stats, format="does-not-exist")
+
+
+def test_json_summary_handles_bad_timestamps():
+    stats = {
+        "total_findings": 0,
+        "severity_counts": {},
+        "rule_counts": {},
+        "start_time": "not-a-timestamp",
+        "end_time": "also-bad",
+    }
+    # Should not raise despite malformed timestamps; duration stays unset.
+    data = json.loads(generate_json_summary(stats))
+    assert data["summary"]["scan_duration_seconds"] is None
+
+
+def test_console_summary_handles_bad_timestamps():
+    stats = {
+        "total_files": 1,
+        "total_findings": 0,
+        "severity_counts": {},
+        "rule_counts": {"check_timeout": 1},
+        "start_time": "bad",
+        "end_time": "worse",
+    }
+    output = format_summary(stats)
+    assert "Scan duration" not in output

--- a/ghast/tests/rules/test_base.py
+++ b/ghast/tests/rules/test_base.py
@@ -1,0 +1,227 @@
+"""
+test_base.py - Tests for the base rule classes and mixin helpers
+
+These helper methods live on the base ``Rule`` mixin classes and are not always
+exercised directly by the concrete rules, so they are tested here against small
+purpose-built rule subclasses.
+"""
+
+import pytest
+
+from ghast.rules.base import (
+    JobRule,
+    StepRule,
+    TokenRule,
+    TriggerRule,
+    WorkflowRule,
+    _is_false,
+    _is_true,
+)
+
+
+class _HelperRule(WorkflowRule, JobRule, TriggerRule, TokenRule):
+    """Concrete rule combining the workflow/job/trigger/token mixins."""
+
+    def __init__(self):
+        super().__init__(
+            rule_id="helper",
+            severity="HIGH",
+            description="Helper rule for testing base mixins",
+            remediation="No remediation",
+        )
+
+    def check(self, workflow, file_path):
+        # Exercise the abstract base implementation via super().
+        return super().check(workflow, file_path)
+
+
+def test_is_false_and_is_true():
+    assert _is_false(False) is True
+    assert _is_false("false") is True
+    assert _is_false("FALSE") is True
+    assert _is_false(True) is False
+    assert _is_false("yes") is False
+
+    assert _is_true(True) is True
+    assert _is_true("true") is True
+    assert _is_true(False) is False
+    assert _is_true("no") is False
+
+
+def test_abstract_check_returns_none():
+    rule = _HelperRule()
+    # The base abstract implementation is a no-op returning None.
+    assert rule.check({}, "wf.yml") is None
+
+
+def test_default_fix_returns_false():
+    rule = _HelperRule()
+    finding = rule.create_finding(message="m", file_path="wf.yml")
+    assert rule.fix({}, finding) is False
+
+
+def test_create_finding_overrides():
+    rule = _HelperRule()
+    finding = rule.create_finding(
+        message="msg",
+        file_path="wf.yml",
+        line_number=3,
+        column=4,
+        remediation="fix it",
+        context={"k": "v"},
+        can_fix=True,
+        severity="LOW",
+    )
+    assert finding.rule_id == "helper"
+    assert finding.severity == "LOW"
+    assert finding.line_number == 3
+    assert finding.column == 4
+    assert finding.remediation == "fix it"
+    assert finding.context == {"k": "v"}
+    assert finding.can_fix is True
+
+
+def test_check_workflow_permissions_missing():
+    rule = _HelperRule()
+    findings = rule.check_workflow_permissions({}, "wf.yml")
+    assert len(findings) == 1
+    assert "missing explicit permissions" in findings[0].message.lower()
+    assert findings[0].can_fix is True
+
+
+def test_check_workflow_permissions_write_all():
+    rule = _HelperRule()
+    findings = rule.check_workflow_permissions({"permissions": "write-all"}, "wf.yml")
+    assert len(findings) == 1
+    assert "write-all" in findings[0].message
+    assert findings[0].can_fix is False
+
+
+def test_check_workflow_permissions_ok():
+    rule = _HelperRule()
+    findings = rule.check_workflow_permissions({"permissions": "read-all"}, "wf.yml")
+    assert findings == []
+
+
+def test_check_job_permissions_missing():
+    rule = _HelperRule()
+    findings = rule.check_job_permissions("build", {}, "wf.yml")
+    assert len(findings) == 1
+    assert "missing explicit permissions in job 'build'" in findings[0].message.lower()
+
+
+def test_check_job_permissions_write_all():
+    rule = _HelperRule()
+    findings = rule.check_job_permissions("build", {"permissions": "write-all"}, "wf.yml")
+    assert len(findings) == 1
+    assert "write-all" in findings[0].message
+    assert "build" in findings[0].message
+
+
+def test_check_job_permissions_ok():
+    rule = _HelperRule()
+    findings = rule.check_job_permissions("build", {"permissions": "read-all"}, "wf.yml")
+    assert findings == []
+
+
+def test_check_job_timeout_triggers():
+    rule = _HelperRule()
+    job = {"steps": [{"run": "echo"} for _ in range(5)]}
+    findings = rule.check_job_timeout("build", job, "wf.yml", min_steps=5)
+    assert len(findings) == 1
+    assert "no timeout-minutes" in findings[0].message
+
+
+def test_check_job_timeout_ok_when_few_steps():
+    rule = _HelperRule()
+    job = {"steps": [{"run": "echo"}]}
+    assert rule.check_job_timeout("build", job, "wf.yml", min_steps=5) == []
+
+
+def test_check_job_timeout_ok_when_set():
+    rule = _HelperRule()
+    job = {"timeout-minutes": 10, "steps": [{"run": "echo"} for _ in range(6)]}
+    assert rule.check_job_timeout("build", job, "wf.yml") == []
+
+
+def test_check_job_runner_missing():
+    rule = _HelperRule()
+    findings = rule.check_job_runner("build", {}, "wf.yml")
+    assert len(findings) == 1
+    assert "missing 'runs-on'" in findings[0].message.lower()
+
+
+def test_check_job_runner_self_hosted_string():
+    rule = _HelperRule()
+    findings = rule.check_job_runner("build", {"runs-on": "self-hosted"}, "wf.yml")
+    assert len(findings) == 1
+    assert "self-hosted runner without labels" in findings[0].message
+
+
+def test_check_job_runner_self_hosted_list_with_labels():
+    rule = _HelperRule()
+    findings = rule.check_job_runner("build", {"runs-on": ["self-hosted", "linux"]}, "wf.yml")
+    assert len(findings) == 1
+    assert findings[0].severity == "LOW"
+
+
+def test_check_job_runner_self_hosted_list_only():
+    rule = _HelperRule()
+    findings = rule.check_job_runner("build", {"runs-on": ["self-hosted"]}, "wf.yml")
+    assert len(findings) == 1
+    # A single-element self-hosted list keeps the rule's own severity.
+    assert findings[0].severity == "HIGH"
+
+
+def test_check_job_runner_github_hosted_ok():
+    rule = _HelperRule()
+    assert rule.check_job_runner("build", {"runs-on": "ubuntu-latest"}, "wf.yml") == []
+
+
+def test_check_high_risk_triggers_dict():
+    rule = _HelperRule()
+    workflow = {"on": {"pull_request_target": {}, "push": {}}}
+    findings = rule.check_high_risk_triggers(workflow, "wf.yml")
+    assert len(findings) == 1
+    assert "pull_request_target" in findings[0].message
+
+
+def test_check_high_risk_triggers_list():
+    rule = _HelperRule()
+    workflow = {"on": ["workflow_run", "push"]}
+    findings = rule.check_high_risk_triggers(workflow, "wf.yml")
+    assert len(findings) == 1
+    assert "workflow_run" in findings[0].message
+
+
+def test_check_high_risk_triggers_none():
+    rule = _HelperRule()
+    workflow = {"on": "push"}
+    assert rule.check_high_risk_triggers(workflow, "wf.yml") == []
+
+
+def test_check_hardcoded_tokens_detects():
+    rule = _HelperRule()
+    workflow = {"env": {"X": "token: 'abcdefghij1234567890'"}}
+    findings = rule.check_hardcoded_tokens(workflow, "wf.yml")
+    assert any("hardcoded token" in f.message.lower() for f in findings)
+
+
+def test_check_hardcoded_tokens_skips_secrets_context():
+    rule = _HelperRule()
+    # The token-like value is preceded by 'secrets.' so it must be skipped.
+    workflow = {"env": {"X": "secrets.GITHUB token: 'abcdefghij1234567890'"}}
+    findings = rule.check_hardcoded_tokens(workflow, "wf.yml")
+    assert findings == []
+
+
+def test_check_hardcoded_tokens_tojson_secrets():
+    rule = _HelperRule()
+    workflow = {"env": {"X": "${{ toJson(secrets) }}"}}
+    findings = rule.check_hardcoded_tokens(workflow, "wf.yml")
+    assert any(f.severity == "CRITICAL" for f in findings)
+
+
+def test_step_rule_is_importable():
+    # StepRule mixin is covered elsewhere; ensure it remains importable.
+    assert issubclass(StepRule, object)

--- a/ghast/tests/rules/test_best_practices_edge.py
+++ b/ghast/tests/rules/test_best_practices_edge.py
@@ -1,0 +1,162 @@
+"""
+test_best_practices_edge.py - Edge-case coverage for best-practice rules
+
+Covers position-marker skipping, non-dict steps, ``fix`` fall-through paths,
+and the reusable-workflow input declaration edge cases.
+"""
+
+from ghast.rules.best_practices import (
+    ContinueOnErrorRule,
+    DeprecatedActionsRule,
+    ReusableWorkflowRule,
+    ShellSpecificationRule,
+    TimeoutRule,
+    WorkflowNameRule,
+)
+
+
+def test_timeout_check_skips_markers_and_non_dict_jobs():
+    rule = TimeoutRule()
+    workflow = {"jobs": {"__line__": 1, "build": "not-a-dict"}}
+    assert rule.check(workflow, "wf.yml") == []
+
+
+def test_timeout_fix_returns_false_without_job_match():
+    rule = TimeoutRule()
+    finding = rule.create_finding(message="no job reference here", file_path="wf.yml")
+    assert rule.fix({"jobs": {}}, finding) is False
+
+
+def test_timeout_fix_returns_false_for_unknown_job():
+    rule = TimeoutRule()
+    finding = rule.create_finding(message="Job 'ghost' has 6 steps", file_path="wf.yml")
+    assert rule.fix({"jobs": {"build": {}}}, finding) is False
+
+
+def test_shell_check_skips_markers_and_non_dict_steps():
+    rule = ShellSpecificationRule()
+    workflow = {
+        "jobs": {
+            "__line__": 1,
+            "build": {"steps": ["not-a-dict", {"run": "line1\nline2"}]},
+        }
+    }
+    findings = rule.check(workflow, "wf.yml")
+    assert len(findings) == 1
+    assert "shell" in findings[0].message.lower()
+
+
+def test_shell_fix_returns_false_when_no_multiline():
+    rule = ShellSpecificationRule()
+    workflow = {"jobs": {"build": {"steps": [{"run": "single line"}]}}}
+    finding = rule.create_finding(
+        message="Multiline script in job 'build' step 1 has no shell specified",
+        file_path="wf.yml",
+    )
+    assert rule.fix(workflow, finding) is False
+
+
+def test_shell_fix_returns_false_without_match():
+    rule = ShellSpecificationRule()
+    finding = rule.create_finding(message="no markers", file_path="wf.yml")
+    assert rule.fix({"jobs": {}}, finding) is False
+
+
+def test_workflow_name_fix_returns_false_when_named():
+    rule = WorkflowNameRule()
+    workflow = {"name": "Existing", "on": "push"}
+    finding = rule.create_finding(message="Missing workflow name", file_path="wf.yml")
+    assert rule.fix(workflow, finding) is False
+
+
+def test_deprecated_check_skips_markers_and_non_dict_steps():
+    rule = DeprecatedActionsRule()
+    workflow = {
+        "jobs": {
+            "__line__": 1,
+            "build": {"steps": ["not-a-dict", {"uses": "actions/checkout@v1"}]},
+        }
+    }
+    findings = rule.check(workflow, "wf.yml")
+    assert any("deprecated action" in f.message.lower() for f in findings)
+
+
+def test_deprecated_fix_uses_replacement_fallback():
+    rule = DeprecatedActionsRule()
+    workflow = {"jobs": {"build": {"steps": [{"uses": "actions/checkout@v1"}]}}}
+    # No 'replacement' in context forces the lookup fallback path.
+    finding = rule.create_finding(
+        message="Deprecated action 'actions/checkout@v1' in job 'build' step 1",
+        file_path="wf.yml",
+        context={},
+    )
+    assert rule.fix(workflow, finding) is True
+    assert workflow["jobs"]["build"]["steps"][0]["uses"] == "actions/checkout@v3"
+
+
+def test_deprecated_fix_returns_false_without_match():
+    rule = DeprecatedActionsRule()
+    finding = rule.create_finding(message="nothing matches", file_path="wf.yml")
+    assert rule.fix({"jobs": {}}, finding) is False
+
+
+def test_continue_on_error_skips_markers_and_non_dict_steps():
+    rule = ContinueOnErrorRule()
+    workflow = {
+        "jobs": {
+            "__line__": 1,
+            "build": {
+                "continue-on-error": True,
+                "steps": ["not-a-dict", {"run": "echo"}],
+            },
+        }
+    }
+    findings = rule.check(workflow, "wf.yml")
+    assert len(findings) == 1
+    assert "continue-on-error" in findings[0].message.lower()
+
+
+def test_reusable_workflow_call_non_dict_trigger():
+    rule = ReusableWorkflowRule()
+    workflow = {
+        "on": {"workflow_call": "not-a-dict"},
+        "jobs": {
+            "__line__": 1,
+            "build": {"steps": [{"run": "echo ${{ inputs.foo }}"}]},
+        },
+    }
+    findings = rule.check(workflow, "wf.yml")
+    assert any("does not define on.workflow_call.inputs" in f.message for f in findings)
+
+
+def test_reusable_workflow_call_non_dict_inputs():
+    rule = ReusableWorkflowRule()
+    workflow = {
+        "on": {"workflow_call": {"inputs": "not-a-dict"}},
+        "jobs": {
+            "build": {"steps": [{"run": "echo ${{ inputs.foo }}"}]},
+        },
+    }
+    findings = rule.check(workflow, "wf.yml")
+    # Non-dict declared inputs are treated as no declarations.
+    assert any("inputs" in f.message.lower() for f in findings)
+
+
+def test_reusable_workflow_no_workflow_call():
+    rule = ReusableWorkflowRule()
+    workflow = {"on": {"push": {}}, "jobs": {"build": {"steps": []}}}
+    assert rule.check(workflow, "wf.yml") == []
+
+
+def test_reusable_workflow_undeclared_inputs():
+    rule = ReusableWorkflowRule()
+    workflow = {
+        "on": {"workflow_call": {"inputs": {"declared": {"type": "string"}}}},
+        "jobs": {
+            "build": {"steps": [{"run": "echo ${{ inputs.declared }} ${{ inputs.missing }}"}]},
+        },
+    }
+    findings = rule.check(workflow, "wf.yml")
+    assert any("undeclared input 'missing'" in f.message for f in findings)
+    # The properly declared input must not be reported.
+    assert not any("input 'declared'" in f.message for f in findings)

--- a/ghast/tests/rules/test_engine_edge.py
+++ b/ghast/tests/rules/test_engine_edge.py
@@ -1,0 +1,129 @@
+"""
+test_engine_edge.py - Edge-case coverage for the rule engine
+
+Covers short-rule-id config resolution, enable/disable of unknown rules, and
+the fix-application branches (unknown rule, interactive confirm/decline, fix
+returning False, and exceptions raised during fix).
+"""
+
+import click
+import pytest
+
+from ghast.core import Finding
+from ghast.rules import Rule, RuleEngine
+
+
+class _FixRule(Rule):
+    """A rule whose fix behaviour is configurable for testing."""
+
+    def __init__(self, rule_id="fixme", behaviour="ok"):
+        super().__init__(
+            rule_id=rule_id,
+            severity="LOW",
+            description="d",
+            remediation="r",
+            category="test",
+        )
+        self.can_fix = True
+        self.behaviour = behaviour
+
+    def check(self, workflow, file_path):
+        return []
+
+    def fix(self, workflow, finding):
+        if self.behaviour == "raise":
+            raise RuntimeError("boom")
+        if self.behaviour == "false":
+            return False
+        return True
+
+
+def _finding(rule_id="fixme"):
+    return Finding(
+        rule_id=rule_id,
+        severity="LOW",
+        message="needs fixing",
+        file_path="wf.yml",
+        can_fix=True,
+    )
+
+
+def test_apply_config_exact_rule_id_disables():
+    engine = RuleEngine(config={"timeout": False})
+    assert engine.get_rule_by_id("timeout").enabled is False
+
+
+def test_apply_config_short_with_check_disables():
+    # short_with_check = "check_deprecated" for rule "deprecated_actions"
+    engine = RuleEngine(config={"check_deprecated": False})
+    assert engine.get_rule_by_id("deprecated_actions").enabled is False
+
+
+def test_apply_config_exact_rule_id_severity():
+    engine = RuleEngine(config={"severity_thresholds": {"timeout": "HIGH"}})
+    assert engine.get_rule_by_id("timeout").severity == "HIGH"
+
+
+def test_apply_config_short_rule_id_disables():
+    # "deprecated_actions" -> short id "deprecated"
+    engine = RuleEngine(config={"deprecated": False})
+    rule = engine.get_rule_by_id("deprecated_actions")
+    assert rule is not None
+    assert rule.enabled is False
+
+
+def test_apply_config_short_rule_id_severity():
+    engine = RuleEngine(config={"severity_thresholds": {"deprecated": "CRITICAL"}})
+    rule = engine.get_rule_by_id("deprecated_actions")
+    assert rule.severity == "CRITICAL"
+
+
+def test_enable_rule_unknown_returns_false():
+    engine = RuleEngine()
+    assert engine.enable_rule("does-not-exist") is False
+
+
+def test_disable_rule_unknown_returns_false():
+    engine = RuleEngine()
+    assert engine.disable_rule("does-not-exist") is False
+
+
+def test_fix_findings_skips_unknown_rule():
+    engine = RuleEngine()
+    result = engine.fix_findings({}, [_finding("unknown_rule_xyz")])
+    assert result["fixes_applied"] == 0
+    assert result["fixes_skipped"] == 1
+
+
+def test_fix_findings_interactive_confirm(monkeypatch):
+    engine = RuleEngine()
+    engine.register_rule(_FixRule(behaviour="ok"))
+    monkeypatch.setattr(click, "confirm", lambda *a, **k: True)
+    result = engine.fix_findings({}, [_finding()], interactive=True)
+    assert result["fixes_applied"] == 1
+
+
+def test_fix_findings_interactive_decline(monkeypatch):
+    engine = RuleEngine()
+    engine.register_rule(_FixRule(behaviour="ok"))
+    monkeypatch.setattr(click, "confirm", lambda *a, **k: False)
+    result = engine.fix_findings({}, [_finding()], interactive=True)
+    assert result["fixes_applied"] == 0
+    assert result["fixes_skipped"] == 1
+
+
+def test_fix_findings_fix_returns_false():
+    engine = RuleEngine()
+    engine.register_rule(_FixRule(behaviour="false"))
+    result = engine.fix_findings({}, [_finding()])
+    assert result["fixes_applied"] == 0
+    assert result["fixes_skipped"] == 1
+
+
+def test_fix_findings_fix_raises(capsys):
+    engine = RuleEngine()
+    engine.register_rule(_FixRule(behaviour="raise"))
+    result = engine.fix_findings({}, [_finding()])
+    assert result["fixes_applied"] == 0
+    assert result["fixes_skipped"] == 1
+    assert "Error fixing" in capsys.readouterr().out

--- a/ghast/tests/rules/test_security_rules_edge.py
+++ b/ghast/tests/rules/test_security_rules_edge.py
@@ -1,0 +1,209 @@
+"""
+test_security_rules_edge.py - Edge-case coverage for security rules
+
+Covers the defensive branches that the happy-path tests don't reach: the
+``__line__``/``__column__`` position-marker keys injected by the YAML loader,
+non-dict steps and jobs, list-form trigger declarations, ``secrets: inherit``
+exposure, and the ``fix`` fall-through paths.
+"""
+
+from ghast.rules.security import (
+    ActionPinningRule,
+    CommandInjectionRule,
+    EnvironmentInjectionRule,
+    PermissionsRule,
+    PoisonedPipelineExecutionRule,
+    TokenSecurityRule,
+)
+
+
+def test_permissions_rule_skips_position_markers_and_non_dict_jobs():
+    rule = PermissionsRule()
+    workflow = {
+        "permissions": "read-all",
+        "jobs": {
+            "__line__": 1,
+            "__column__": 1,
+            "build": "not-a-dict",
+        },
+    }
+    # All jobs are skipped; only workflow-level permission (present) is checked.
+    assert rule.check(workflow, "wf.yml") == []
+
+
+def test_permissions_rule_job_write_all():
+    rule = PermissionsRule()
+    findings = rule.check_job_permissions("build", {"permissions": "write-all"}, "wf.yml")
+    assert len(findings) == 1
+    assert "overly permissive" in findings[0].message.lower()
+
+
+def test_permissions_rule_fix_job_level():
+    rule = PermissionsRule()
+    workflow = {"jobs": {"build": {"runs-on": "ubuntu-latest"}}}
+    finding = rule.create_finding(
+        message="Missing explicit permissions in job 'build'", file_path="wf.yml"
+    )
+    assert rule.fix(workflow, finding) is True
+    assert workflow["jobs"]["build"]["permissions"] == "read-all"
+
+
+def test_permissions_rule_fix_unknown_job_returns_false():
+    rule = PermissionsRule()
+    workflow = {"jobs": {"build": {}}}
+    finding = rule.create_finding(
+        message="Missing explicit permissions in job 'ghost'", file_path="wf.yml"
+    )
+    assert rule.fix(workflow, finding) is False
+
+
+def test_permissions_rule_fix_no_match_returns_false():
+    rule = PermissionsRule()
+    finding = rule.create_finding(message="something unrelated", file_path="wf.yml")
+    assert rule.fix({}, finding) is False
+
+
+def test_ppe_list_form_triggers_and_secrets_inherit():
+    rule = PoisonedPipelineExecutionRule()
+    workflow = {
+        "on": ["push", "pull_request_target"],
+        "jobs": {
+            "__line__": 1,
+            "build": {
+                "secrets": "inherit",
+                "steps": [
+                    "not-a-dict",
+                    {"uses": "actions/checkout@v3"},
+                ],
+            },
+        },
+    }
+    findings = rule.check(workflow, "wf.yml")
+    assert any("secrets: inherit" in f.message.lower() for f in findings)
+
+
+def test_ppe_dict_form_triggers():
+    rule = PoisonedPipelineExecutionRule()
+    workflow = {
+        "on": {"pull_request_target": {"branches": ["main"]}},
+        "jobs": {
+            "build": {
+                "steps": [
+                    {
+                        "uses": "actions/checkout@v3",
+                        "with": {"ref": "${{ github.head_ref }}"},
+                    },
+                    {"run": "echo hi"},
+                ],
+            }
+        },
+    }
+    findings = rule.check(workflow, "wf.yml")
+    assert any("poisoned pipeline execution" in f.message.lower() for f in findings)
+
+
+def test_ppe_modifies_environment_after_untrusted_checkout():
+    rule = PoisonedPipelineExecutionRule()
+    workflow = {
+        "on": "pull_request_target",
+        "jobs": {
+            "build": {
+                "steps": [
+                    {
+                        "uses": "actions/checkout@v3",
+                        "with": {"ref": "${{ github.event.pull_request.head.ref }}"},
+                    },
+                    "not-a-dict-step",
+                    {"run": "echo X=1 >> $GITHUB_ENV"},
+                ],
+            }
+        },
+    }
+    findings = rule.check(workflow, "wf.yml")
+    assert any("modifies environment" in f.message.lower() for f in findings)
+
+
+def test_command_injection_skips_markers_and_non_dict_steps():
+    rule = CommandInjectionRule()
+    workflow = {
+        "jobs": {
+            "__line__": 1,
+            "build": {
+                "steps": [
+                    "not-a-dict",
+                    {"run": "echo ${{ github.event.comment.body }}"},
+                ],
+            },
+        }
+    }
+    findings = rule.check(workflow, "wf.yml")
+    assert len(findings) == 1
+    assert "untrusted" in findings[0].message.lower()
+
+
+def test_environment_injection_skips_markers_and_non_dict_steps():
+    rule = EnvironmentInjectionRule()
+    workflow = {
+        "jobs": {
+            "__line__": 1,
+            "build": {
+                "steps": [
+                    "not-a-dict",
+                    {"uses": "actions/checkout@v3"},
+                    {"run": "echo X=1 >> $GITHUB_ENV"},
+                ],
+            },
+        }
+    }
+    findings = rule.check(workflow, "wf.yml")
+    assert any("github_env" in f.message.lower() for f in findings)
+
+
+def test_token_security_skips_markers_and_non_dict_steps():
+    rule = TokenSecurityRule()
+    workflow = {
+        "jobs": {
+            "__line__": 1,
+            "build": {
+                "steps": [
+                    "not-a-dict",
+                    {"uses": "actions/checkout@v3"},
+                ],
+            },
+        }
+    }
+    findings = rule.check(workflow, "wf.yml")
+    assert any("credential persistence" in f.message.lower() for f in findings)
+
+
+def test_token_security_fix_returns_false_for_unrelated():
+    rule = TokenSecurityRule()
+    finding = rule.create_finding(message="unrelated message", file_path="wf.yml")
+    assert rule.fix({}, finding) is False
+
+
+def test_token_security_fix_returns_false_for_missing_job():
+    rule = TokenSecurityRule()
+    workflow = {"jobs": {}}
+    finding = rule.create_finding(
+        message="actions/checkout in job 'build' step 1 does not disable credential persistence",
+        file_path="wf.yml",
+    )
+    assert rule.fix(workflow, finding) is False
+
+
+def test_action_pinning_skips_markers_and_non_dict_steps():
+    rule = ActionPinningRule()
+    workflow = {
+        "jobs": {
+            "__line__": 1,
+            "build": {
+                "steps": [
+                    "not-a-dict",
+                    {"uses": "actions/checkout@v3"},
+                ],
+            },
+        }
+    }
+    findings = rule.check(workflow, "wf.yml")
+    assert any("not pinned" in f.message.lower() for f in findings)

--- a/ghast/tests/test_cli_edge.py
+++ b/ghast/tests/test_cli_edge.py
@@ -1,0 +1,172 @@
+"""
+test_cli_edge.py - Edge-case coverage for the command-line interface
+
+Covers the no-subcommand banner, --no-color, --disable, invalid-config error
+paths, repository-mode fix, the various fix/dry-run summary branches, config
+generation to stdout, and analyze success/failure paths.
+"""
+
+import os
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from ghast.cli import _prepare_scan, cli
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+def _write_workflow(directory, name, content):
+    workflows_dir = os.path.join(directory, ".github", "workflows")
+    os.makedirs(workflows_dir, exist_ok=True)
+    path = os.path.join(workflows_dir, name)
+    with open(path, "w") as f:
+        f.write(content)
+    return path
+
+
+SECURE_WORKFLOW = """name: Secure
+on: push
+permissions: read-all
+jobs:
+  build:
+    permissions: read-all
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+"""
+
+
+def test_cli_no_subcommand_shows_banner(cli_runner):
+    result = cli_runner.invoke(cli, [])
+    assert result.exit_code == 0
+    assert "Use `ghast --help`" in result.output
+
+
+def test_scan_no_color(cli_runner, insecure_workflow_file):
+    result = cli_runner.invoke(cli, ["scan", insecure_workflow_file, "--no-color"])
+    assert "Scanning single workflow file" in result.output
+
+
+def test_scan_with_disable(cli_runner, mock_repo):
+    result = cli_runner.invoke(cli, ["scan", mock_repo, "--disable", "timeout"])
+    assert "Scan Summary" in result.output
+
+
+def test_scan_invalid_config_file(cli_runner, mock_repo, tmp_path):
+    bad_config = tmp_path / "bad.yml"
+    bad_config.write_text("unknown_option: true\n")
+    result = cli_runner.invoke(cli, ["scan", mock_repo, "--config", str(bad_config)])
+    assert result.exit_code == 1
+    assert "Error loading config file" in result.output
+
+
+def test_prepare_scan_none_config_with_disable(monkeypatch, mock_repo, tmp_path):
+    # Force load_config to return None so the disable branch initialises it.
+    import ghast.cli as cli_module
+
+    cfg = tmp_path / "cfg.yml"
+    cfg.write_text("check_timeout: true\n")
+    monkeypatch.setattr(cli_module, "load_config", lambda path: None)
+
+    findings, stats, config_data = _prepare_scan(
+        mock_repo,
+        strict=False,
+        config=str(cfg),
+        severity_threshold="LOW",
+        disable=("timeout",),
+    )
+    assert config_data == {"check_timeout": False}
+
+
+def test_fix_invalid_config_file(cli_runner, mock_repo, tmp_path):
+    bad_config = tmp_path / "bad.yml"
+    bad_config.write_text("unknown_option: true\n")
+    result = cli_runner.invoke(cli, ["fix", mock_repo, "--config", str(bad_config)])
+    assert result.exit_code == 1
+    assert "Error loading config file" in result.output
+
+
+def test_fix_repository_mode(cli_runner, mock_repo):
+    result = cli_runner.invoke(cli, ["fix", mock_repo, "--disable", "tokens"])
+    assert result.exit_code == 0
+    assert "Scanning repository" in result.output
+    assert "Fix Summary" in result.output
+
+
+def test_fix_repository_no_workflows(cli_runner, tmp_path):
+    empty = tmp_path / "empty_repo"
+    empty.mkdir()
+    result = cli_runner.invoke(cli, ["fix", str(empty)])
+    assert result.exit_code == 1
+    assert "No workflows found" in result.output
+
+
+def test_fix_clean_workflow_no_issues(cli_runner, tmp_path):
+    repo = tmp_path / "clean"
+    repo.mkdir()
+    _write_workflow(str(repo), "secure.yml", SECURE_WORKFLOW)
+    result = cli_runner.invoke(cli, ["fix", str(repo)])
+    assert result.exit_code == 0
+    assert "No issues found" in result.output
+
+
+def test_fix_some_unfixable(cli_runner, insecure_workflow_file, temp_dir):
+    # The insecure workflow has findings, but none of them are auto-fixable
+    # at HIGH+ severity, exercising the "could not be fixed" branch.
+    result = cli_runner.invoke(
+        cli, ["fix", insecure_workflow_file, "--severity-threshold", "CRITICAL"]
+    )
+    assert result.exit_code == 0
+    assert "Fix Summary" in result.output
+
+
+def test_fix_dry_run_clean_workflow(cli_runner, tmp_path):
+    repo = tmp_path / "clean_dry"
+    repo.mkdir()
+    _write_workflow(str(repo), "secure.yml", SECURE_WORKFLOW)
+    result = cli_runner.invoke(cli, ["fix", str(repo), "--dry-run"])
+    assert result.exit_code == 0
+    assert "No issues found" in result.output
+
+
+def test_fix_dry_run_unfixable(cli_runner, insecure_workflow_file):
+    result = cli_runner.invoke(
+        cli, ["fix", insecure_workflow_file, "--dry-run", "--severity-threshold", "CRITICAL"]
+    )
+    assert result.exit_code == 0
+    assert "Some issues cannot be automatically fixed" in result.output
+
+
+def test_config_generate_stdout(cli_runner):
+    result = cli_runner.invoke(cli, ["config", "--generate"])
+    assert result.exit_code == 0
+    assert "check_timeout" in result.output
+
+
+def test_config_invalid(cli_runner, tmp_path):
+    bad_config = tmp_path / "bad.yml"
+    bad_config.write_text("unknown_option: true\n")
+    result = cli_runner.invoke(cli, ["config", "--config", str(bad_config)])
+    assert result.exit_code == 1
+    assert "Config validation failed" in result.output
+
+
+def test_analyze_non_workflow(cli_runner, tmp_path):
+    not_a_workflow = tmp_path / "plain.yml"
+    not_a_workflow.write_text("hello: world\n")
+    result = cli_runner.invoke(cli, ["analyze", str(not_a_workflow)])
+    assert result.exit_code == 1
+    assert "Error analyzing file" in result.output
+
+
+def test_analyze_clean_workflow(cli_runner, tmp_path):
+    clean = tmp_path / "secure.yml"
+    clean.write_text(SECURE_WORKFLOW)
+    result = cli_runner.invoke(cli, ["analyze", str(clean)])
+    assert result.exit_code == 0
+    assert "No issues found" in result.output

--- a/ghast/tests/utils/test_file_handler_edge.py
+++ b/ghast/tests/utils/test_file_handler_edge.py
@@ -1,0 +1,33 @@
+"""
+test_file_handler_edge.py - Edge-case coverage for file handling utilities
+
+Covers the safe_write_file failure/restore path and the
+get_modified_workflows missing-directory short-circuit.
+"""
+
+import os
+
+from ghast.utils import file_handler
+from ghast.utils.file_handler import get_modified_workflows, safe_write_file
+
+
+def test_safe_write_file_failure_restores_backup(tmp_path, monkeypatch, capsys):
+    target = tmp_path / "file.txt"
+    target.write_text("original")
+
+    def _boom(*args, **kwargs):
+        raise OSError("move failed")
+
+    # Force the atomic move to fail after the backup has been created.
+    monkeypatch.setattr(file_handler.shutil, "move", _boom)
+
+    result = safe_write_file(str(target), "new content", create_backup=True)
+    assert result is False
+    # Original content is preserved via backup restore.
+    assert target.read_text() == "original"
+    assert "Error writing file" in capsys.readouterr().err
+
+
+def test_get_modified_workflows_no_directory(tmp_path):
+    # No .github/workflows directory present.
+    assert get_modified_workflows(str(tmp_path)) == []

--- a/ghast/tests/utils/test_formatter.py
+++ b/ghast/tests/utils/test_formatter.py
@@ -1,0 +1,304 @@
+"""
+test_formatter.py - Tests for console output formatting utilities
+"""
+
+import io
+
+import pytest
+
+from ghast.utils import formatter
+from ghast.utils.formatter import (
+    COLORS,
+    SEVERITY_COLORS,
+    SEVERITY_SYMBOLS,
+    colorize,
+    format_code_block,
+    format_count,
+    format_duration,
+    format_error,
+    format_file_path,
+    format_header,
+    format_info,
+    format_line_number,
+    format_progress,
+    format_rule_id,
+    format_severity,
+    format_success,
+    format_table,
+    format_warning,
+    get_console_width,
+    indent,
+    print_error,
+    print_info,
+    print_success,
+    print_warning,
+    supports_color,
+    wrap_text,
+)
+
+
+@pytest.fixture
+def force_color(monkeypatch):
+    """Force colorize() to emit ANSI codes regardless of environment."""
+    monkeypatch.setattr(formatter, "supports_color", lambda: True)
+
+
+@pytest.fixture
+def no_color(monkeypatch):
+    """Force colorize() to skip ANSI codes."""
+    monkeypatch.setattr(formatter, "supports_color", lambda: False)
+
+
+def test_supports_color_disabled_by_no_color(monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert supports_color() is False
+
+
+def test_supports_color_disabled_by_ghast_no_color(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("GHAST_NO_COLOR", "1")
+    assert supports_color() is False
+
+
+def test_supports_color_windows_with_ansicon(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("GHAST_NO_COLOR", raising=False)
+    monkeypatch.setattr(formatter.platform, "system", lambda: "Windows")
+    monkeypatch.setenv("ANSICON", "1")
+    monkeypatch.delenv("WT_SESSION", raising=False)
+    monkeypatch.delenv("ConEmuANSI", raising=False)
+    monkeypatch.delenv("TERM_PROGRAM", raising=False)
+    assert supports_color() is True
+
+
+def test_supports_color_windows_without_support(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("GHAST_NO_COLOR", raising=False)
+    monkeypatch.setattr(formatter.platform, "system", lambda: "Windows")
+    for var in ("ANSICON", "WT_SESSION", "ConEmuANSI", "TERM_PROGRAM"):
+        monkeypatch.delenv(var, raising=False)
+    assert supports_color() is False
+
+
+def test_supports_color_unix_tty(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("GHAST_NO_COLOR", raising=False)
+    monkeypatch.setattr(formatter.platform, "system", lambda: "Linux")
+
+    class _TTY(io.StringIO):
+        def isatty(self):
+            return True
+
+    monkeypatch.setattr(formatter.sys, "stdout", _TTY())
+    assert supports_color() is True
+
+
+def test_supports_color_unix_not_tty(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("GHAST_NO_COLOR", raising=False)
+    monkeypatch.setattr(formatter.platform, "system", lambda: "Linux")
+
+    class _NotTTY(io.StringIO):
+        def isatty(self):
+            return False
+
+    monkeypatch.setattr(formatter.sys, "stdout", _NotTTY())
+    assert supports_color() is False
+
+
+def test_colorize_with_color(force_color):
+    result = colorize("hello", "red")
+    assert result == f"{COLORS['red']}hello{COLORS['reset']}"
+
+
+def test_colorize_unknown_color_returns_plain(force_color):
+    assert colorize("hello", "not-a-color") == "hello"
+
+
+def test_colorize_without_color_support(no_color):
+    assert colorize("hello", "red") == "hello"
+
+
+def test_get_console_width_default(monkeypatch):
+    monkeypatch.setattr(formatter.shutil, "get_terminal_size", lambda: (123, 40))
+    assert get_console_width() == 123
+
+
+def test_get_console_width_fallback(monkeypatch):
+    def _boom():
+        raise OSError("no terminal")
+
+    monkeypatch.setattr(formatter.shutil, "get_terminal_size", _boom)
+    assert get_console_width() == 80
+
+
+def test_format_severity_known(no_color):
+    result = format_severity("CRITICAL")
+    assert SEVERITY_SYMBOLS["CRITICAL"] in result
+    assert "CRITICAL" in result
+
+
+def test_format_severity_unknown(no_color):
+    result = format_severity("UNKNOWN")
+    assert result.startswith("•")
+    assert "UNKNOWN" in result
+
+
+def test_format_rule_id(force_color):
+    result = format_rule_id("check_timeout")
+    assert "check_timeout" in result
+    assert COLORS["bright_blue"] in result
+
+
+def test_format_file_path_relative(no_color):
+    result = format_file_path("/repo/sub/file.yml", relative_to="/repo")
+    assert result == "sub/file.yml"
+
+
+def test_format_file_path_no_relative(no_color):
+    result = format_file_path("/repo/sub/file.yml")
+    assert result == "/repo/sub/file.yml"
+
+
+def test_format_line_number_none():
+    assert format_line_number(None) == ""
+
+
+def test_format_line_number_value(no_color):
+    assert format_line_number(42) == ":42"
+
+
+def test_format_header_levels(no_color, monkeypatch):
+    monkeypatch.setattr(formatter, "get_console_width", lambda: 80)
+    h1 = format_header("Title", level=1)
+    assert "TITLE" in h1
+    assert "=" in h1
+
+    h2 = format_header("Section", level=2)
+    assert "Section" in h2
+    assert "-" in h2
+
+    h3 = format_header("Sub", level=3)
+    assert "Sub" in h3
+
+
+def test_format_message_helpers(no_color):
+    assert "Done" in format_success("Done")
+    assert "Careful" in format_warning("Careful")
+    assert "Boom" in format_error("Boom")
+    assert "Note" in format_info("Note")
+
+
+def test_indent():
+    text = "line1\nline2"
+    result = indent(text, level=2, indent_size=2)
+    assert result == "    line1\n    line2"
+
+
+def test_format_code_block(monkeypatch):
+    monkeypatch.setattr(formatter, "get_console_width", lambda: 10)
+    result = format_code_block("print(1)", language="python")
+    assert "print(1)" in result
+    assert "-" * 10 in result
+
+
+def test_format_table(no_color):
+    headers = ["Name", "Count"]
+    rows = [["foo", "1"], ["barbaz", "22"]]
+    table = format_table(headers, rows)
+    assert "Name" in table
+    assert "barbaz" in table
+    assert "-+-" in table
+
+
+def test_format_table_without_header_styling(no_color):
+    table = format_table(["A"], [["x"]], format_headers=False)
+    assert table.startswith("A")
+
+
+def test_format_table_empty():
+    assert format_table([], []) == ""
+    assert format_table(["A"], []) == ""
+
+
+def test_format_progress(no_color):
+    result = format_progress(5, 10, width=10)
+    assert "50%" in result
+    assert "(5/10)" in result
+
+
+def test_format_progress_overflow(no_color):
+    # current > total should clamp at 100%
+    result = format_progress(15, 10, width=10)
+    assert "100%" in result
+
+
+def test_format_progress_zero_total(no_color):
+    # total of 0 must not raise ZeroDivisionError (max(1, total) guard)
+    result = format_progress(0, 0, width=10)
+    assert "0%" in result
+
+
+@pytest.mark.parametrize(
+    "seconds,expected_substr",
+    [
+        (0.0000005, "µs"),
+        (0.05, "ms"),
+        (5.0, "s"),
+        (125.0, "m "),
+    ],
+)
+def test_format_duration(seconds, expected_substr):
+    assert expected_substr in format_duration(seconds)
+
+
+def test_format_count_singular():
+    assert format_count(1, "file") == "1 file"
+
+
+def test_format_count_plural_default():
+    assert format_count(3, "file") == "3 files"
+
+
+def test_format_count_plural_explicit():
+    assert format_count(2, "child", "children") == "2 children"
+
+
+def test_wrap_text_explicit_width():
+    text = "the quick brown fox jumps"
+    wrapped = wrap_text(text, width=10)
+    for line in wrapped.splitlines():
+        assert len(line) <= 10
+
+
+def test_wrap_text_preserves_blank_lines():
+    text = "para one\n\npara two"
+    wrapped = wrap_text(text, width=80)
+    assert "" in wrapped.splitlines()
+
+
+def test_wrap_text_default_width(monkeypatch):
+    monkeypatch.setattr(formatter, "get_console_width", lambda: 80)
+    wrapped = wrap_text("short text")
+    assert wrapped == "short text"
+
+
+def test_print_helpers(no_color):
+    out = io.StringIO()
+    err = io.StringIO()
+    print_error("err", stream=err)
+    print_warning("warn", stream=out)
+    print_success("ok", stream=out)
+    print_info("info", stream=out)
+
+    assert "err" in err.getvalue()
+    out_value = out.getvalue()
+    assert "warn" in out_value
+    assert "ok" in out_value
+    assert "info" in out_value
+
+
+def test_severity_maps_complete():
+    for severity in ("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"):
+        assert severity in SEVERITY_COLORS
+        assert severity in SEVERITY_SYMBOLS

--- a/ghast/tests/utils/test_yaml_handler_edge.py
+++ b/ghast/tests/utils/test_yaml_handler_edge.py
@@ -1,0 +1,71 @@
+"""
+test_yaml_handler_edge.py - Edge-case coverage for YAML position handling
+
+Covers non-scalar mapping keys during index building, root-scoped position
+lookups, dead-root cleanup, missing-directory file discovery, and the
+context-extraction error fallback.
+"""
+
+import weakref
+
+import yaml
+
+from ghast.utils import yaml_handler
+from ghast.utils.yaml_handler import (
+    PositionTrackedDict,
+    _build_position_indexes,
+    _cleanup_dead_roots,
+    extract_line_from_file,
+    find_github_workflow_files,
+    find_yaml_files,
+    get_position,
+    load_yaml_with_positions,
+)
+
+
+def test_build_position_indexes_skips_non_scalar_keys():
+    # A complex (sequence) mapping key produces a non-scalar key node.
+    node = yaml.compose("? [a, b]\n: value\n")
+    by_id, by_path = _build_position_indexes(node, {})
+    # The complex key is skipped, so only the root path is recorded.
+    assert by_path == {(): (1, 0)}
+
+
+def test_get_position_with_root_path_and_object():
+    workflow = load_yaml_with_positions("on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n")
+    assert isinstance(workflow, PositionTrackedDict)
+
+    # Path-based lookup against an explicit root.
+    line, _ = get_position(("jobs",), root=workflow)
+    assert line is not None
+
+    # Object-identity lookup against an explicit root.
+    jobs = workflow["jobs"]
+    obj_line, _ = get_position(jobs, root=workflow)
+    assert obj_line is not None
+
+
+def test_cleanup_dead_roots_removes_dead_entry():
+    obj = PositionTrackedDict()
+    root_id = id(obj)
+    yaml_handler._root_refs[root_id] = weakref.ref(obj)
+    yaml_handler._positions_by_root_id[root_id] = {}
+    yaml_handler._paths_by_root_id[root_id] = {}
+
+    del obj  # weakref now resolves to None
+
+    _cleanup_dead_roots()
+    assert root_id not in yaml_handler._root_refs
+    assert root_id not in yaml_handler._positions_by_root_id
+
+
+def test_find_yaml_files_missing_directory(tmp_path):
+    assert find_yaml_files(str(tmp_path / "nope")) == []
+
+
+def test_find_github_workflow_files_missing_directory(tmp_path):
+    assert find_github_workflow_files(str(tmp_path)) == []
+
+
+def test_extract_line_from_file_error_returns_empty():
+    assert extract_line_from_file("/path/does/not/exist.yml", 5) == []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,5 +90,17 @@ python_files = "test_*.py"
 python_functions = "test_*"
 python_classes = "Test*"
 
+[tool.coverage.run]
+source = ["ghast"]
+omit = ["ghast/tests/*"]
+
+[tool.coverage.report]
+show_missing = true
+fail_under = 100
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+]
+
 [tool.flake8]
 max-line-length = 100


### PR DESCRIPTION
## Summary
This PR adds extensive edge-case test coverage across the codebase to achieve 100% code coverage. Nine new test modules have been added covering previously untested branches in core functionality, rules, utilities, and CLI components. Additionally, coverage configuration has been added to enforce 100% coverage going forward.

## Key Changes

### New Test Modules
- **`test_formatter.py`** (304 lines): Comprehensive tests for console output formatting utilities including color support detection, text wrapping, table formatting, progress bars, and duration/count formatting
- **`test_fixer_edge.py`** (237 lines): Edge-case coverage for auto-remediation including interactive prompting, error handling during fixing/dumping, and fixer fall-through branches
- **`test_base.py`** (227 lines): Tests for base rule classes and mixin helpers covering permission checks, timeout validation, runner configuration, and trigger analysis
- **`test_security_rules_edge.py`** (209 lines): Edge-case coverage for security rules including position-marker handling, non-dict steps/jobs, and fix fall-through paths
- **`test_cli_edge.py`** (172 lines): CLI edge-case coverage including no-subcommand banner, config validation errors, repository-mode fixes, and various summary branches
- **`test_best_practices_edge.py`** (162 lines): Edge-case coverage for best-practice rules including position-marker skipping and fix fall-through paths
- **`test_config_edge.py`** (139 lines): Configuration management edge-cases covering enum/list serialization, validation errors, and auto-discovery
- **`test_engine_edge.py`** (129 lines): Rule engine edge-cases including short-rule-id resolution and fix-application branches
- **`test_yaml_handler_edge.py`** (71 lines): YAML position handling edge-cases including non-scalar keys and dead-root cleanup
- **`test_scanner_edge.py`** (53 lines): Workflow scanner edge-cases including backward-compatibility shims and rule-id normalization
- **`test_report_edge.py`** (51 lines): Report generation edge-cases including summary-only JSON and malformed timestamps
- **`test_file_handler_edge.py`** (33 lines): File handling utilities edge-cases including safe-write failures and missing directories

### Configuration Changes
- **`pyproject.toml`**: Added `[tool.coverage.run]` and `[tool.coverage.report]` sections to enforce 100% code coverage with `fail_under = 100`

### Source Code Modifications
- **`ghast/__init__.py`**: Added `# pragma: no cover` comment to `if __name__ == "__main__"` block
- **`ghast/cli.py`**: Added `# pragma: no cover` comment to `if __name__ == "__main__"` block
- **`ghast/reports/report.py`**: Updated docstring for `generate_html_report()` function

## Notable Implementation Details
- Tests use pytest fixtures and monkeypatching extensively to isolate behavior and control environment variables
- Edge-case tests focus on error paths, boundary conditions, and fall-through branches not covered by happy-path tests
- Position-marker handling (`__line__`, `__column__`) is tested to ensure YAML loader artifacts are properly skipped
- Interactive prompting and user confirmation flows are tested using Click's testing utilities
- Coverage configuration uses `exclude_lines` to skip pragma-marked code blocks that cannot be reasonably tested

https://claude.ai/code/session_0189dccUZbhppbwDu759gXZ8