### PR TITLE
Refactor YAML handler for better code clarity and testability

### DIFF
--- a/ghast/rules/best_practices.py
+++ b/ghast/rules/best_practices.py
@@ -6,7 +6,7 @@ This module provides rules focused on best practices rather than strict security
 
 import os
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, cast
 
 from ..core import Finding
 from ..utils.yaml_handler import get_position
@@ -343,7 +343,10 @@ class ReusableWorkflowRule(Rule):
                         )
                     )
 
-        on_section = workflow.get("on", workflow.get(True, {}))
+        # ``on`` may surface as the string "on" (position-preserving loader) or
+        # as the boolean ``True`` key when parsed with a stock YAML 1.1 loader.
+        workflow_keys = cast(Dict[Any, Any], workflow)
+        on_section = workflow_keys.get("on", workflow_keys.get(True, {}))
         if not isinstance(on_section, dict):
             return findings
 

--- a/ghast/tests/utils/test_yaml_handler_edge.py
+++ b/ghast/tests/utils/test_yaml_handler_edge.py
@@ -6,6 +6,7 @@ lookups, dead-root cleanup, missing-directory file discovery, and the
 context-extraction error fallback.
 """
 
+import gc
 import weakref
 
 import yaml
@@ -57,6 +58,19 @@ def test_cleanup_dead_roots_removes_dead_entry():
     _cleanup_dead_roots()
     assert root_id not in yaml_handler._root_refs
     assert root_id not in yaml_handler._positions_by_root_id
+
+
+def test_weakref_callback_cleans_up_dead_root():
+    # Loading registers a weakref whose callback removes the root's position
+    # data once the loaded object is garbage collected.
+    loaded = load_yaml_with_positions("on: push\njobs: {}\n")
+    root_id = id(loaded)
+    assert root_id in yaml_handler._positions_by_root_id
+
+    del loaded
+    gc.collect()
+    assert root_id not in yaml_handler._positions_by_root_id
+    assert root_id not in yaml_handler._root_refs
 
 
 def test_find_yaml_files_missing_directory(tmp_path):

--- a/ghast/utils/yaml_handler.py
+++ b/ghast/utils/yaml_handler.py
@@ -106,13 +106,19 @@ def _construct_mapping_with_preserved_bool_keys(
     return mapping
 
 
+def _construct_position_tracked_list(
+    loader: LineColumnLoader, node: yaml.nodes.SequenceNode
+) -> PositionTrackedList:
+    return PositionTrackedList(loader.construct_sequence(node))
+
+
 LineColumnLoader.add_constructor(
     yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
     _construct_mapping_with_preserved_bool_keys,
 )
 LineColumnLoader.add_constructor(
     yaml.resolver.BaseResolver.DEFAULT_SEQUENCE_TAG,
-    lambda loader, node: PositionTrackedList(loader.construct_sequence(node)),
+    _construct_position_tracked_list,
 )
 
 
@@ -154,7 +160,13 @@ def load_yaml_with_positions(content: str) -> Dict[str, Any]:
     root_id = id(loaded)
     _positions_by_root_id[root_id] = by_id
     _paths_by_root_id[root_id] = by_path
-    _root_refs[root_id] = weakref.ref(loaded, lambda _ref, rid=root_id: _cleanup_root(rid))
+
+    def _on_root_dead(
+        _ref: "weakref.ReferenceType[PositionTrackedDict]", rid: int = root_id
+    ) -> None:
+        _cleanup_root(rid)
+
+    _root_refs[root_id] = weakref.ref(loaded, _on_root_dead)
     _cleanup_dead_roots()
     return loaded
 


### PR DESCRIPTION
## Summary
This PR improves code quality in the YAML handling utilities by extracting lambda functions into named functions, adding explicit type annotations, and improving test coverage for weakref cleanup behavior.

## Key Changes

- **Extract lambda to named function**: Replaced the inline lambda in `LineColumnLoader.add_constructor()` with a properly named `_construct_position_tracked_list()` function for better readability and debuggability.

- **Improve weakref callback clarity**: Extracted the weakref callback lambda in `load_yaml_with_positions()` into a named nested function `_on_root_dead()` with explicit type annotations, making the cleanup behavior more transparent and easier to understand.

- **Add comprehensive weakref test**: Added `test_weakref_callback_cleans_up_dead_root()` to verify that the weakref callback properly triggers garbage collection cleanup of position tracking data when YAML objects are deleted.

- **Fix type safety in best_practices.py**: Added explicit `cast()` to clarify that workflow keys can be of any type (not just strings), addressing the case where YAML 1.1 loaders may use boolean `True` as a key instead of the string `"on"`. Added explanatory comment documenting this behavior.

## Implementation Details

The refactoring maintains identical runtime behavior while improving code maintainability. The extracted functions have the same signatures and behavior as their lambda predecessors, but are now named and can be more easily tested and debugged. The new test validates that the weakref cleanup mechanism works correctly by explicitly triggering garbage collection.

https://claude.ai/code/session_0189dccUZbhppbwDu759gXZ8